### PR TITLE
Jorge/black

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,14 @@
+name: Black
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable  
+        with:
+          src: "./clingox"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.9
+        stages: [post-commit]
+        always_run: true
+        args: [ ./clingox/]

--- a/.pylintrc
+++ b/.pylintrc
@@ -149,7 +149,8 @@ disable=raw-checker-failed,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
-        use-symbolic-message-instead
+        use-symbolic-message-instead,
+        implicit-str-concat,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/clingox/backend.py
+++ b/clingox/backend.py
@@ -1,4 +1,4 @@
-'''
+"""
 This module provides a backend wrapper to work with symbols instead of integer
 literals.
 
@@ -43,24 +43,24 @@ Python's `with` statement:
     >>> ctl.solve(on_model=lambda m: print("Answer: {}".format(m)))
     Answer: a b
     SAT
-'''
+"""
 
 from typing import Iterable, Sequence, Tuple
 from itertools import chain
 from clingo import HeuristicType, Symbol, Backend, TruthValue
 
-__all__ = ['SymbolicBackend']
+__all__ = ["SymbolicBackend"]
 
 
 def _add_sign(lit: int, sign: bool):
-    '''
+    """
     Invert the literal if sign is negative and otherwise leave it untouched.
-    '''
+    """
     return lit if sign else -lit
 
 
 class SymbolicBackend:
-    '''
+    """
     Backend wrapper providing an interface to extend a logic program. It
     mirrors the interface of clingo's Backend, but using Symbols rather than
     integers to represent literals.
@@ -74,18 +74,18 @@ class SymbolicBackend:
     The `SymbolicBackend` is a context manager and must be used with Python's
     `with` statement or be attached to an already managed
     `clingo.backend.Backend` object.
-    '''
+    """
 
     backend: Backend
-    '''
+    """
     The underlying `clingo.backend.Backend` object.
-    '''
+    """
 
     def __init__(self, backend: Backend):
         self.backend: Backend = backend
 
     def __enter__(self):
-        '''
+        """
         Initialize the backend.
 
         Returns
@@ -95,23 +95,28 @@ class SymbolicBackend:
         Notes
         -----
         Must be called before using the backend.
-        '''
+        """
         self.backend.__enter__()
         return self
 
     def __exit__(self, type_, value, traceback):
-        '''
+        """
         Finalize the backend.
 
         Notes
         -----
         Follows Python's __exit__ conventions. Does not suppress exceptions.
-        '''
+        """
         return self.backend.__exit__(type_, value, traceback)
 
-    def add_acyc_edge(self, node_u: int, node_v: int, pos_condition: Sequence[Symbol],
-                      neg_condition: Sequence[Symbol]) -> None:
-        '''
+    def add_acyc_edge(
+        self,
+        node_u: int,
+        node_v: int,
+        pos_condition: Sequence[Symbol],
+        neg_condition: Sequence[Symbol],
+    ) -> None:
+        """
         Add an edge directive to the underlying backend.
 
         Parameters
@@ -124,12 +129,16 @@ class SymbolicBackend:
             List of atoms forming positive part of the condition.
         neg_condition
             List of atoms forming negated part of the condition.
-        '''
-        condition = chain(self._add_lits(pos_condition, True), self._add_lits(neg_condition, False))
+        """
+        condition = chain(
+            self._add_lits(pos_condition, True), self._add_lits(neg_condition, False)
+        )
         self.backend.add_acyc_edge(node_u, node_v, list(condition))
 
-    def add_assume(self, pos_atoms: Sequence[Symbol] = (), neg_atoms: Sequence[Symbol] = ()) -> None:
-        '''
+    def add_assume(
+        self, pos_atoms: Sequence[Symbol] = (), neg_atoms: Sequence[Symbol] = ()
+    ) -> None:
+        """
         Add assumptions to the underlying backend.
 
         Parameters
@@ -138,12 +147,14 @@ class SymbolicBackend:
             Atoms to assume true.
         neg_atoms
             Atoms to assume false.
-        '''
-        literals = chain(self._add_lits(pos_atoms, True), self._add_lits(neg_atoms, False))
+        """
+        literals = chain(
+            self._add_lits(pos_atoms, True), self._add_lits(neg_atoms, False)
+        )
         self.backend.add_assume(list(literals))
 
     def add_external(self, atom: Symbol, value: TruthValue = TruthValue.False_) -> None:
-        '''
+        """
         Mark an atom as external and set its truth value.
 
         Parameters
@@ -156,12 +167,19 @@ class SymbolicBackend:
         Notes
         -----
         Can also be used to release an external atom using `TruthValue.Release`.
-        '''
+        """
         return self.backend.add_external(self.backend.add_atom(atom), value)
 
-    def add_heuristic(self, atom: Symbol, type_: HeuristicType, bias: int, priority: int,
-                      pos_condition: Sequence[Symbol], neg_condition: Sequence[Symbol]) -> None:
-        '''
+    def add_heuristic(
+        self,
+        atom: Symbol,
+        type_: HeuristicType,
+        bias: int,
+        priority: int,
+        pos_condition: Sequence[Symbol],
+        neg_condition: Sequence[Symbol],
+    ) -> None:
+        """
         Add a heuristic directive to the underlying backend.
 
         Parameters
@@ -179,13 +197,21 @@ class SymbolicBackend:
             condition.
         neg_condition
             List of program literals forming the negated part of the condition.
-        '''
-        condition = chain(self._add_lits(pos_condition, True), self._add_lits(neg_condition, False))
-        return self.backend.add_heuristic(self.backend.add_atom(atom), type_, bias, priority, list(condition))
+        """
+        condition = chain(
+            self._add_lits(pos_condition, True), self._add_lits(neg_condition, False)
+        )
+        return self.backend.add_heuristic(
+            self.backend.add_atom(atom), type_, bias, priority, list(condition)
+        )
 
-    def add_minimize(self, priority: int, pos_literals: Sequence[Tuple[Symbol, int]],
-                     neg_literals: Sequence[Tuple[Symbol, int]]) -> None:
-        '''
+    def add_minimize(
+        self,
+        priority: int,
+        pos_literals: Sequence[Tuple[Symbol, int]],
+        neg_literals: Sequence[Tuple[Symbol, int]],
+    ) -> None:
+        """
         Add a minimize constraint to the underlying backend.
 
         Parameters
@@ -198,24 +224,31 @@ class SymbolicBackend:
         neg_literals
             List of pairs of atoms and weights forming the negated
             part of the condition.
-        '''
-        literals = chain(self._add_wlits(pos_literals, True), self._add_wlits(neg_literals, False))
+        """
+        literals = chain(
+            self._add_wlits(pos_literals, True), self._add_wlits(neg_literals, False)
+        )
         return self.backend.add_minimize(priority, list(literals))
 
     def add_project(self, atoms: Sequence[Symbol]) -> None:
-        '''
+        """
         Add a project statement to the underlying backend.
 
         Parameters
         ----------
         atoms
             List of atoms to project on.
-        '''
+        """
         return self.backend.add_project(list(self._add_lits(atoms, True)))
 
-    def add_rule(self, head: Sequence[Symbol] = (), pos_body: Sequence[Symbol] = (), neg_body: Sequence[Symbol] = (),
-                 choice: bool = False) -> None:
-        '''
+    def add_rule(
+        self,
+        head: Sequence[Symbol] = (),
+        pos_body: Sequence[Symbol] = (),
+        neg_body: Sequence[Symbol] = (),
+        choice: bool = False,
+    ) -> None:
+        """
         Add a disjuntive or choice rule to the underlying backend.
 
         Parameters
@@ -233,13 +266,21 @@ class SymbolicBackend:
         -----
         Integrity constraints and normal rules can be added by using an empty or
         singleton head list, respectively.
-        '''
+        """
         body = chain(self._add_lits(pos_body, True), self._add_lits(neg_body, False))
-        return self.backend.add_rule(list(self._add_lits(head, True)), list(body), choice)
+        return self.backend.add_rule(
+            list(self._add_lits(head, True)), list(body), choice
+        )
 
-    def add_weight_rule(self, head: Sequence[Symbol], lower: int, pos_body: Sequence[Tuple[Symbol, int]],
-                        neg_body: Sequence[Tuple[Symbol, int]], choice: bool = False) -> None:
-        '''
+    def add_weight_rule(
+        self,
+        head: Sequence[Symbol],
+        lower: int,
+        pos_body: Sequence[Tuple[Symbol, int]],
+        neg_body: Sequence[Tuple[Symbol, int]],
+        choice: bool = False,
+    ) -> None:
+        """
         Add a disjunctive or choice rule with one weight constraint with a lower
         bound in the body to the underlying backend.
 
@@ -257,19 +298,26 @@ class SymbolicBackend:
             negative body of the weight constraint.
         choice
             Whether to add a disjunctive or choice rule.
-        '''
+        """
         body = chain(self._add_wlits(pos_body, True), self._add_wlits(neg_body, False))
-        return self.backend.add_weight_rule(list(self._add_lits(head, True)), lower, list(body), choice)
+        return self.backend.add_weight_rule(
+            list(self._add_lits(head, True)), lower, list(body), choice
+        )
 
     def _add_lits(self, atoms: Sequence[Symbol], sign: bool) -> Iterable[int]:
-        '''
+        """
         Map the given atoms to program literals with the given sign.
-        '''
+        """
         return (_add_sign(self.backend.add_atom(symbol), sign) for symbol in atoms)
 
-    def _add_wlits(self, weighted_symbols: Sequence[Tuple[Symbol, int]], sign: bool) -> Iterable[Tuple[int, int]]:
-        '''
+    def _add_wlits(
+        self, weighted_symbols: Sequence[Tuple[Symbol, int]], sign: bool
+    ) -> Iterable[Tuple[int, int]]:
+        """
         Map the given weighted atoms to weighted program literals with the
         given sign.
-        '''
-        return ((_add_sign(self.backend.add_atom(x), sign), w) for (x, w) in weighted_symbols)
+        """
+        return (
+            (_add_sign(self.backend.add_atom(x), sign), w)
+            for (x, w) in weighted_symbols
+        )

--- a/clingox/program.py
+++ b/clingox/program.py
@@ -1,4 +1,4 @@
-'''
+"""
 This module provides functions to work with ground programs.
 
 This includes constructing a ground representation using an observer, pretty
@@ -38,10 +38,21 @@ c :- b.
 a
 b c a
 ```
-'''
+"""
 
-from typing import (Callable, Iterable, List, Mapping, MutableMapping, MutableSequence, NamedTuple, Optional, Sequence,
-                    Tuple, TypeVar)
+from typing import (
+    Callable,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    MutableSequence,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+)
 from dataclasses import dataclass, field
 from functools import singledispatch
 from itertools import chain
@@ -49,9 +60,23 @@ from copy import copy
 
 from clingo import Backend, HeuristicType, Observer, Symbol, TruthValue
 
-__all__ = ['add_to_backend', 'pretty_str', 'remap', 'Edge', 'External', 'Fact',
-           'Heuristic', 'Minimize', 'Program', 'ProgramObserver', 'Project',
-           'Remapping', 'Rule', 'Show', 'WeightRule']
+__all__ = [
+    "add_to_backend",
+    "pretty_str",
+    "remap",
+    "Edge",
+    "External",
+    "Fact",
+    "Heuristic",
+    "Minimize",
+    "Program",
+    "ProgramObserver",
+    "Project",
+    "Remapping",
+    "Rule",
+    "Show",
+    "WeightRule",
+]
 __pdoc__ = {}
 
 Atom = int
@@ -59,13 +84,25 @@ Literal = int
 Weight = int
 OutputTable = Mapping[Atom, Symbol]
 AtomMap = Callable[[Atom], Atom]
-Statement = TypeVar('Statement', 'Fact', 'Show', 'Rule', 'WeightRule', 'Heuristic', 'Edge', 'Minimize', 'External',
-                    'Project')
+Statement = TypeVar(
+    "Statement",
+    "Fact",
+    "Show",
+    "Rule",
+    "WeightRule",
+    "Heuristic",
+    "Edge",
+    "Minimize",
+    "External",
+    "Project",
+)
 
 
 @singledispatch
-def pretty_str(stm, output_atoms: OutputTable) -> str:  # pylint: disable=unused-argument
-    '''
+def pretty_str(
+    stm, output_atoms: OutputTable  # pylint: disable=unused-argument
+) -> str:
+    """
     Pretty print statements.
 
     Parameters
@@ -78,13 +115,13 @@ def pretty_str(stm, output_atoms: OutputTable) -> str:  # pylint: disable=unused
     Returns
     -------
     The string representation of the statement.
-    '''
-    assert False, 'unexpected type'
+    """
+    assert False, "unexpected type"
 
 
 @singledispatch
 def remap(stm, mapping: AtomMap):  # pylint: disable=unused-argument
-    '''
+    """
     Remap literals in the given statement with the provided mapping.
 
     Parameters
@@ -101,13 +138,13 @@ def remap(stm, mapping: AtomMap):  # pylint: disable=unused-argument
     See Also
     --------
     Remapping
-    '''
-    assert False, 'unexpected type'
+    """
+    assert False, "unexpected type"
 
 
 @singledispatch
 def add_to_backend(stm, backend: Backend):  # pylint: disable=unused-argument
-    '''
+    """
     Add statements to the backend using the provided mapping to map literals.
 
     Parameters
@@ -116,51 +153,53 @@ def add_to_backend(stm, backend: Backend):  # pylint: disable=unused-argument
         The statement to add to the backend.
     backend
         The backend.
-    '''
-    assert False, 'unexpected type'
+    """
+    assert False, "unexpected type"
 
 
 def _pretty_str_lit(stm: Literal, output_atoms: OutputTable) -> str:
-    '''
+    """
     Pretty print literals and atoms.
-    '''
+    """
     atom = abs(stm)
     if atom in output_atoms:
         atom_str = str(output_atoms[atom])
     else:
-        atom_str = f'__x{atom}'
+        atom_str = f"__x{atom}"
 
-    return f'not {atom_str}' if stm < 0 else atom_str
+    return f"not {atom_str}" if stm < 0 else atom_str
 
 
-def _pretty_str_rule_head(choice: bool, has_body: bool, head: Sequence[Atom], output_atoms: OutputTable) -> str:
-    '''
+def _pretty_str_rule_head(
+    choice: bool, has_body: bool, head: Sequence[Atom], output_atoms: OutputTable
+) -> str:
+    """
     Pretty print the head of a rule including the implication symbol if
     necessary.
-    '''
-    ret = ''
+    """
+    ret = ""
 
     if choice:
-        ret += '{'
-    ret += '; '.join(_pretty_str_lit(lit, output_atoms) for lit in head)
+        ret += "{"
+    ret += "; ".join(_pretty_str_lit(lit, output_atoms) for lit in head)
     if choice:
-        ret += '}'
+        ret += "}"
 
     if has_body or (not head and not choice):
-        ret += ' :- '
+        ret += " :- "
 
     return ret
 
 
 def _pretty_str_truth_value(stm: TruthValue):
-    '''
+    """
     Pretty print a truth value.
-    '''
+    """
     if stm == TruthValue.False_:
-        return 'False'
+        return "False"
     if stm == TruthValue.True_:
-        return 'True'
-    return 'Free'
+        return "True"
+    return "Free"
 
 
 def _remap_lit(literal: Literal, mapping: AtomMap) -> Atom:
@@ -168,31 +207,33 @@ def _remap_lit(literal: Literal, mapping: AtomMap) -> Atom:
 
 
 def _remap_seq(literals: Sequence[Literal], mapping: AtomMap):
-    '''
+    """
     Apply the mapping to a sequence of literals or atoms.
-    '''
+    """
     return [_remap_lit(lit, mapping) for lit in literals]
 
 
 def _remap_wseq(literals: Sequence[Tuple[Literal, Weight]], mapping: AtomMap):
-    '''
+    """
     Apply the mapping to a sequence of weighted literals or atoms.
-    '''
+    """
     return [(_remap_lit(lit, mapping), weight) for lit, weight in literals]
 
 
 def _remap_stms(stms: MutableSequence[Statement], mapping: AtomMap):
-    '''
+    """
     Remap the given statements.
-    '''
+    """
     for i, stm in enumerate(stms):
         stms[i] = remap(stm, mapping)
 
 
-def _add_stms_to_backend(stms: Iterable[Statement], backend: Backend, mapping: Optional[AtomMap]):
-    '''
+def _add_stms_to_backend(
+    stms: Iterable[Statement], backend: Backend, mapping: Optional[AtomMap]
+):
+    """
     Remap the given statements returning a list with the result.
-    '''
+    """
     for stm in stms:
         if mapping:
             add_to_backend(remap(stm, mapping), backend)
@@ -201,77 +242,86 @@ def _add_stms_to_backend(stms: Iterable[Statement], backend: Backend, mapping: O
 
 
 class Fact(NamedTuple):
-    '''
+    """
     Ground representation of a fact.
-    '''
+    """
+
     symbol: Symbol
 
 
 @pretty_str.register(Fact)
-def _pretty_str_fact(stm: Fact, output_atoms: OutputTable) -> str:  # pylint: disable=unused-argument
-    '''
+def _pretty_str_fact(
+    stm: Fact, output_atoms: OutputTable
+) -> str:  # pylint: disable=unused-argument
+    """
     Pretty print a fact.
-    '''
-    return f'{stm.symbol}.'
+    """
+    return f"{stm.symbol}."
 
 
 @remap.register(Fact)
 def _remap_fact(stm: Fact, mapping: AtomMap) -> Fact:  # pylint: disable=unused-argument
-    '''
+    """
     Remap a fact statement.
-    '''
+    """
     return stm
 
 
 @add_to_backend.register(Fact)
-def _add_to_backend_fact(stm: Fact, backend: Backend) -> None:  # pylint: disable=unused-argument
-    '''
+def _add_to_backend_fact(
+    stm: Fact, backend: Backend
+) -> None:  # pylint: disable=unused-argument
+    """
     Add a fact to the backend.
 
     This does nothing to not interfere with the mapping of literals. If facts
     are to be mapped, then this should be done manually beforehand.
-    '''
+    """
 
 
 class Show(NamedTuple):
-    '''
+    """
     Ground representation of a show statements.
-    '''
+    """
+
     symbol: Symbol
     condition: Sequence[Literal]
 
 
 @pretty_str.register(Show)
 def _pretty_str_show(stm: Show, output_atoms: OutputTable) -> str:
-    '''
+    """
     Pretty print a fact.
-    '''
-    body = ', '.join(_pretty_str_lit(lit, output_atoms) for lit in stm.condition)
+    """
+    body = ", ".join(_pretty_str_lit(lit, output_atoms) for lit in stm.condition)
     return f'#show {stm.symbol}{": " if body else ""}{body}.'
 
 
 @remap.register(Show)
 def _remap_show(stm: Show, mapping: AtomMap) -> Show:
-    '''
+    """
     Remap a show statetment.
-    '''
+    """
     return Show(stm.symbol, _remap_seq(stm.condition, mapping))
 
 
 @add_to_backend.register(Show)
-def _add_to_backend_show(stm: Show, backend: Backend) -> None:  # pylint: disable=unused-argument
-    '''
+def _add_to_backend_show(
+    stm: Show, backend: Backend
+) -> None:  # pylint: disable=unused-argument
+    """
     Add a show statement to the backend.
 
     Note that this currently does nothing because backend does not yet support
     adding to the symbol table.
-    '''
+    """
 
 
 class Rule(NamedTuple):
-    '''
+    """
     Ground representation of disjunctive and choice rules.
-    '''
+    """
+
     choice: bool
     head: Sequence[Atom]
     body: Sequence[Literal]
@@ -279,35 +329,38 @@ class Rule(NamedTuple):
 
 @pretty_str.register(Rule)
 def _pretty_str_rule(stm: Rule, output_atoms: OutputTable) -> str:
-    '''
+    """
     Pretty print a rule.
-    '''
+    """
     head = _pretty_str_rule_head(stm.choice, bool(stm.body), stm.head, output_atoms)
-    body = ', '.join(_pretty_str_lit(lit, output_atoms) for lit in stm.body)
+    body = ", ".join(_pretty_str_lit(lit, output_atoms) for lit in stm.body)
 
-    return f'{head}{body}.'
+    return f"{head}{body}."
 
 
 @remap.register(Rule)
 def _remap_rule(stm: Rule, mapping: AtomMap) -> Rule:
-    '''
+    """
     Remap literals in a rule.
-    '''
-    return Rule(stm.choice, _remap_seq(stm.head, mapping), _remap_seq(stm.body, mapping))
+    """
+    return Rule(
+        stm.choice, _remap_seq(stm.head, mapping), _remap_seq(stm.body, mapping)
+    )
 
 
 @add_to_backend.register(Rule)
 def _add_to_backend_rule(stm: Rule, backend: Backend) -> None:
-    '''
+    """
     Add a rule to the backend.
-    '''
+    """
     backend.add_rule(stm.head, stm.body, stm.choice)
 
 
 class WeightRule(NamedTuple):
-    '''
+    """
     Ground representation of rules with a weight constraint in the body.
-    '''
+    """
+
     choice: bool
     head: Sequence[Atom]
     lower_bound: Weight
@@ -316,133 +369,146 @@ class WeightRule(NamedTuple):
 
 @pretty_str.register(WeightRule)
 def _pretty_str_weight_rule(stm: WeightRule, output_atoms: OutputTable) -> str:
-    '''
+    """
     Pretty print a rule or weight rule.
-    '''
+    """
     head = _pretty_str_rule_head(stm.choice, bool(stm.body), stm.head, output_atoms)
-    body = ', '.join(f'{weight},{i}: {_pretty_str_lit(literal, output_atoms)}'
-                     for i, (literal, weight) in enumerate(stm.body))
+    body = ", ".join(
+        f"{weight},{i}: {_pretty_str_lit(literal, output_atoms)}"
+        for i, (literal, weight) in enumerate(stm.body)
+    )
 
-    return f'{head}{stm.lower_bound}{{{body}}}.'
+    return f"{head}{stm.lower_bound}{{{body}}}."
 
 
 @remap.register(WeightRule)
 def _remap_weight_rule(stm: WeightRule, mapping: AtomMap) -> WeightRule:
-    '''
+    """
     Remap literals in a weight rule.
-    '''
-    return WeightRule(stm.choice, _remap_seq(stm.head, mapping), stm.lower_bound, _remap_wseq(stm.body, mapping))
+    """
+    return WeightRule(
+        stm.choice,
+        _remap_seq(stm.head, mapping),
+        stm.lower_bound,
+        _remap_wseq(stm.body, mapping),
+    )
 
 
 @add_to_backend.register(WeightRule)
 def _add_to_backend_weight_rule(stm: WeightRule, backend: Backend) -> None:
-    '''
+    """
     Add a weight rule to the backend.
-    '''
+    """
     backend.add_weight_rule(stm.head, stm.lower_bound, stm.body, stm.choice)
 
 
 class Project(NamedTuple):
-    '''
+    """
     Ground representation of project statements.
-    '''
+    """
+
     atom: Atom
 
 
 @pretty_str.register(Project)
 def _pretty_str_project(stm: Project, output_atoms: OutputTable) -> str:
-    '''
+    """
     Pretty print a project statement.
-    '''
-    return f'#project {_pretty_str_lit(stm.atom, output_atoms)}.'
+    """
+    return f"#project {_pretty_str_lit(stm.atom, output_atoms)}."
 
 
 @remap.register(Project)
 def _remap_project(stm: Project, mapping: AtomMap):
-    '''
+    """
     Remap project statement.
-    '''
+    """
     return Project(mapping(stm.atom))
 
 
 @add_to_backend.register(Project)
 def _add_to_backend_project(stm: Project, backend: Backend):
-    '''
+    """
     Add a project statement to the backend.
-    '''
+    """
     backend.add_project([stm.atom])
 
 
 class External(NamedTuple):
-    '''
+    """
     Ground representation of external atoms.
-    '''
+    """
+
     atom: Atom
     value: TruthValue
 
 
 @pretty_str.register(External)
 def _pretty_print_external(stm: External, output_atoms: OutputTable) -> str:
-    '''
+    """
     Pretty print an external.
-    '''
-    return f'#external {_pretty_str_lit(stm.atom, output_atoms)}. [{_pretty_str_truth_value(stm.value)}]'
+    """
+    return f"#external {_pretty_str_lit(stm.atom, output_atoms)}. [{_pretty_str_truth_value(stm.value)}]"
 
 
 @remap.register(External)
 def _remap_external(stm: External, mapping: AtomMap) -> External:
-    '''
+    """
     Remap the external.
-    '''
+    """
     return External(mapping(stm.atom), stm.value)
 
 
 @add_to_backend.register(External)
 def _add_to_backend_external(stm: External, backend: Backend):
-    '''
+    """
     Add an external statement to the backend remapping its atom.
-    '''
+    """
     backend.add_external(stm.atom, stm.value)
 
 
 class Minimize(NamedTuple):
-    '''
+    """
     Ground representation of a minimize statement.
-    '''
+    """
+
     priority: Weight
     literals: Sequence[Tuple[Literal, Weight]]
 
 
 @pretty_str.register(Minimize)
 def _pretty_print_minimize(stm, output_atoms) -> str:
-    '''
+    """
     Pretty print a minimize statement.
-    '''
-    body = '; '.join(f'{weight}@{stm.priority},{i}: {_pretty_str_lit(literal, output_atoms)}'
-                     for i, (literal, weight) in enumerate(stm.literals))
-    return f'#minimize{{{body}}}.'
+    """
+    body = "; ".join(
+        f"{weight}@{stm.priority},{i}: {_pretty_str_lit(literal, output_atoms)}"
+        for i, (literal, weight) in enumerate(stm.literals)
+    )
+    return f"#minimize{{{body}}}."
 
 
 @remap.register(Minimize)
 def _remap_minimize(stm: Minimize, mapping: AtomMap) -> Minimize:
-    '''
+    """
     Remap the literals in the minimize statement.
-    '''
+    """
     return Minimize(stm.priority, _remap_wseq(stm.literals, mapping))
 
 
 @add_to_backend.register(Minimize)
 def _add_to_backend_minimize(stm: Minimize, backend: Backend):
-    '''
+    """
     Add a minimize statement to the backend.
-    '''
+    """
     backend.add_minimize(stm.priority, stm.literals)
 
 
 class Heuristic(NamedTuple):
-    '''
+    """
     Ground representation of a heuristic statement.
-    '''
+    """
+
     atom: Atom
     type_: HeuristicType
     bias: Weight
@@ -451,15 +517,15 @@ class Heuristic(NamedTuple):
 
 
 def _pretty_str_heuristic_type(type_):
-    return str(type_).replace('HeuristicType.', '')
+    return str(type_).replace("HeuristicType.", "")
 
 
 @pretty_str.register(Heuristic)
 def _pretty_str_heuristic(stm: Heuristic, output_atoms: OutputTable) -> str:
-    '''
+    """
     Pretty print a heuristic statement.
-    '''
-    body = ', '.join(_pretty_str_lit(lit, output_atoms) for lit in stm.condition)
+    """
+    body = ", ".join(_pretty_str_lit(lit, output_atoms) for lit in stm.condition)
     head = _pretty_str_lit(stm.atom, output_atoms)
     type_ = _pretty_str_heuristic_type(stm.type_)
     return f'#heuristic {head}{": " if body else ""}{body}. [{stm.bias}@{stm.priority}, {type_}]'
@@ -467,24 +533,31 @@ def _pretty_str_heuristic(stm: Heuristic, output_atoms: OutputTable) -> str:
 
 @remap.register(Heuristic)
 def _remap_heuristic(stm: Heuristic, mapping: AtomMap) -> Heuristic:
-    '''
+    """
     Remap the heuristic statement.
-    '''
-    return Heuristic(mapping(stm.atom), stm.type_, stm.bias, stm.priority, _remap_seq(stm.condition, mapping))
+    """
+    return Heuristic(
+        mapping(stm.atom),
+        stm.type_,
+        stm.bias,
+        stm.priority,
+        _remap_seq(stm.condition, mapping),
+    )
 
 
 @add_to_backend.register(Heuristic)
 def _add_to_backend_heuristic(stm: Heuristic, backend: Backend) -> None:
-    '''
+    """
     Add a heurisitic statement to the backend.
-    '''
+    """
     backend.add_heuristic(stm.atom, stm.type_, stm.bias, stm.priority, stm.condition)
 
 
 class Edge(NamedTuple):
-    '''
+    """
     Ground representation of a heuristic statement.
-    '''
+    """
+
     u: int
     v: int
     condition: Sequence[Literal]
@@ -492,81 +565,82 @@ class Edge(NamedTuple):
 
 @pretty_str.register(Edge)
 def _pretty_str_edge(stm: Edge, output_atoms: OutputTable) -> str:
-    '''
+    """
     Pretty print a heuristic statement.
-    '''
-    body = ', '.join(_pretty_str_lit(lit, output_atoms) for lit in stm.condition)
+    """
+    body = ", ".join(_pretty_str_lit(lit, output_atoms) for lit in stm.condition)
     return f'#edge ({stm.u},{stm.v}){": " if body else ""}{body}.'
 
 
 @remap.register(Edge)
 def _remap_edge(stm: Edge, mapping: AtomMap) -> Edge:
-    '''
+    """
     Remap an edge statement.
-    '''
+    """
     return Edge(stm.u, stm.v, _remap_seq(stm.condition, mapping))
 
 
 @add_to_backend.register(Edge)
 def _add_to_backend_edge(stm: Edge, backend: Backend) -> None:
-    '''
+    """
     Add an edge statement to the backend remapping its literals.
-    '''
+    """
     backend.add_acyc_edge(stm.u, stm.v, stm.condition)
 
 
 @dataclass
 class Program:  # pylint: disable=too-many-instance-attributes
-    '''
+    """
     Ground program representation.
 
     Although inefficient, the string representation of this program is parsable
     by clingo.
-    '''
+    """
+
     output_atoms: MutableMapping[Atom, Symbol] = field(default_factory=dict)
-    '''
+    """
     A mapping from program atoms to symbols.
-    '''
+    """
     shows: List[Show] = field(default_factory=list)
-    '''
+    """
     A list of show statements.
-    '''
+    """
     facts: List[Fact] = field(default_factory=list)
-    '''
+    """
     A list of facts.
-    '''
+    """
     rules: List[Rule] = field(default_factory=list)
-    '''
+    """
     A list of rules.
-    '''
+    """
     weight_rules: List[WeightRule] = field(default_factory=list)
-    '''
+    """
     A list of weight rules.
-    '''
+    """
     heuristics: List[Heuristic] = field(default_factory=list)
-    '''
+    """
     A list of heuristic statements.
-    '''
+    """
     edges: List[Edge] = field(default_factory=list)
-    '''
+    """
     A list of edge statements.
-    '''
+    """
     minimizes: List[Minimize] = field(default_factory=list)
-    '''
+    """
     A list of minimize statements.
-    '''
+    """
     externals: List[External] = field(default_factory=list)
-    '''
+    """
     A list of external statements.
-    '''
+    """
     projects: Optional[List[Project]] = None
-    '''
+    """
     A list of project statements.
-    '''
+    """
     assumptions: List[Literal] = field(default_factory=list)
-    '''
+    """
     A list of assumptions in form of program literals.
-    '''
+    """
 
     def _pretty_stms(self, arg: Iterable[Statement], sort: bool) -> Iterable[str]:
         if sort:
@@ -586,18 +660,18 @@ class Program:  # pylint: disable=too-many-instance-attributes
         # This is to inform that there is an empty projection statement.
         # It might be worth to allow writing just #project.
         if not self.projects:
-            return ['#project x: #false.']
+            return ["#project x: #false."]
         arg = sorted(self.projects) if sort else self.projects
         return (pretty_str(project, self.output_atoms) for project in arg)
 
-    def sort(self) -> 'Program':
-        '''
+    def sort(self) -> "Program":
+        """
         Sort the statements in the program inplace.
 
         Returns
         -------
         A reference to self.
-        '''
+        """
         self.shows.sort()
         self.facts.sort()
         self.rules.sort()
@@ -612,8 +686,8 @@ class Program:  # pylint: disable=too-many-instance-attributes
 
         return self
 
-    def remap(self, mapping: AtomMap) -> 'Program':
-        '''
+    def remap(self, mapping: AtomMap) -> "Program":
+        """
         Remap the literals in the program inplace.
 
         Parameters
@@ -628,7 +702,7 @@ class Program:  # pylint: disable=too-many-instance-attributes
         See Also
         --------
         remap
-        '''
+        """
         _remap_stms(self.shows, mapping)
         _remap_stms(self.facts, mapping)
         _remap_stms(self.rules, mapping)
@@ -641,12 +715,16 @@ class Program:  # pylint: disable=too-many-instance-attributes
             _remap_stms(self.projects, mapping)
         for i, lit in enumerate(self.assumptions):
             self.assumptions[i] = _remap_lit(lit, mapping)
-        self.output_atoms = {mapping(lit): sym for lit, sym in self.output_atoms.items()}
+        self.output_atoms = {
+            mapping(lit): sym for lit, sym in self.output_atoms.items()
+        }
 
         return self
 
-    def add_to_backend(self, backend: Backend, mapping: Optional[AtomMap] = None) -> 'Program':
-        '''
+    def add_to_backend(
+        self, backend: Backend, mapping: Optional[AtomMap] = None
+    ) -> "Program":
+        """
         Add the program to the given backend with an optional mapping.
 
         Note that the output table cannot be added to the backend for technical
@@ -667,7 +745,7 @@ class Program:  # pylint: disable=too-many-instance-attributes
         See Also
         --------
         add_to_backend
-        '''
+        """
 
         _add_stms_to_backend(self.shows, backend, mapping)
         _add_stms_to_backend(self.facts, backend, mapping)
@@ -683,13 +761,14 @@ class Program:  # pylint: disable=too-many-instance-attributes
             else:
                 backend.add_project([])
 
-        backend.add_assume([_remap_lit(lit, mapping) if mapping else lit
-                            for lit in self.assumptions])
+        backend.add_assume(
+            [_remap_lit(lit, mapping) if mapping else lit for lit in self.assumptions]
+        )
 
         return self
 
     def pretty_str(self, sort: bool = True) -> str:
-        '''
+        """
         Return a readable string represenation of the program.
 
         Parameters
@@ -700,38 +779,41 @@ class Program:  # pylint: disable=too-many-instance-attributes
         Returns
         -------
         The string representation of the program.
-        '''
-        return '\n'.join(chain(
-            self._pretty_stms(self.shows, sort),
-            self._pretty_stms(self.facts, sort),
-            self._pretty_stms(self.rules, sort),
-            self._pretty_stms(self.weight_rules, sort),
-            self._pretty_stms(self.heuristics, sort),
-            self._pretty_stms(self.edges, sort),
-            self._pretty_stms(self.minimizes, sort),
-            self._pretty_stms(self.externals, sort),
-            self._pretty_projects(sort),
-            self._pretty_assumptions(sort)))
+        """
+        return "\n".join(
+            chain(
+                self._pretty_stms(self.shows, sort),
+                self._pretty_stms(self.facts, sort),
+                self._pretty_stms(self.rules, sort),
+                self._pretty_stms(self.weight_rules, sort),
+                self._pretty_stms(self.heuristics, sort),
+                self._pretty_stms(self.edges, sort),
+                self._pretty_stms(self.minimizes, sort),
+                self._pretty_stms(self.externals, sort),
+                self._pretty_projects(sort),
+                self._pretty_assumptions(sort),
+            )
+        )
 
-    def copy(self) -> 'Program':
-        '''
+    def copy(self) -> "Program":
+        """
         Return a shallow copy of the program copying all mutable state.
 
         Returns
         -------
         A shallow copy of the program.
-        '''
+        """
         return copy(self)
 
     def __str__(self) -> str:
-        '''
+        """
         Return a readable string represenation of the program.
-        '''
+        """
         return self.pretty_str()
 
 
 class Remapping:
-    '''
+    """
     This class maps existing literals to fresh literals as created by the
     backend.
 
@@ -743,11 +825,14 @@ class Remapping:
         The output table to initialize the mapping with.
     facts
         A list of facts each of which will receive a fresh program atom.
-    '''
+    """
+
     _backend: Backend
     _map: MutableMapping[Atom, Atom]
 
-    def __init__(self, backend: Backend, output_atoms: OutputTable, facts: Iterable[Fact] = None):
+    def __init__(
+        self, backend: Backend, output_atoms: OutputTable, facts: Iterable[Fact] = None
+    ):
         self._backend = backend
         self._map = {}
         for atom, sym in output_atoms.items():
@@ -758,7 +843,7 @@ class Remapping:
                 backend.add_rule([backend.add_atom(fact.symbol)])
 
     def __call__(self, atom: Atom) -> Atom:
-        '''
+        """
         Map the given program atom to the corresponding atom in the backend.
 
         If the literal was not mapped during initialization, a new literal is
@@ -772,18 +857,18 @@ class Remapping:
         Returns
         -------
         The remapped program atom.
-        '''
+        """
         if atom not in self._map:
             self._map[atom] = self._backend.add_atom()
 
         return self._map[atom]
 
 
-__pdoc__['Remapping.__call__'] = True
+__pdoc__["Remapping.__call__"] = True
 
 
 class ProgramObserver(Observer):
-    '''
+    """
     Program observer to build a ground program representation while grounding.
 
     This class explicitly ignores theory atoms because they already have a
@@ -793,35 +878,36 @@ class ProgramObserver(Observer):
     ----------
     program
         The program to add statements to.
-    '''
+    """
+
     _program: Program
 
     def __init__(self, program: Program):
         self._program = program
 
     def begin_step(self) -> None:
-        '''
+        """
         Resets the assumptions.
-        '''
+        """
         self._program.assumptions.clear()
 
     def output_atom(self, symbol: Symbol, atom: Atom) -> None:
-        '''
+        """
         Add the given atom to the list of facts or output table.
-        '''
+        """
         if atom != 0:
             self._program.output_atoms[atom] = symbol
         else:
             self._program.facts.append(Fact(symbol))
 
     def output_term(self, symbol: Symbol, condition: Sequence[Literal]) -> None:
-        '''
+        """
         Add a term to the output table.
-        '''
+        """
         self._program.shows.append(Show(symbol, condition))
 
     def rule(self, choice: bool, head: Sequence[Atom], body: Sequence[Literal]) -> None:
-        '''
+        """
         Add a rule to the ground representation.
 
         Parameters
@@ -832,12 +918,17 @@ class ProgramObserver(Observer):
             List of program atoms forming the rule head.
         body
             List of program literals forming the rule body.
-        '''
+        """
         self._program.rules.append(Rule(choice, head, body))
 
-    def weight_rule(self, choice: bool, head: Sequence[Atom], lower_bound: Weight,
-                    body: Sequence[Tuple[Literal, Weight]]) -> None:
-        '''
+    def weight_rule(
+        self,
+        choice: bool,
+        head: Sequence[Atom],
+        lower_bound: Weight,
+        body: Sequence[Tuple[Literal, Weight]],
+    ) -> None:
+        """
         Add a weight rule to the ground representation.
 
         Parameters
@@ -851,24 +942,24 @@ class ProgramObserver(Observer):
         body
             List of weighted literals (pairs of literal and weight) forming the
             elements of the weight constraint.
-        '''
+        """
         self._program.weight_rules.append(WeightRule(choice, head, lower_bound, body))
 
     def project(self, atoms: Sequence[Atom]) -> None:
-        '''
+        """
         Add a project statement to the ground representation.
 
         Parameters
         ----------
         atoms
             The program atoms to project on.
-        '''
+        """
         if self._program.projects is None:
             self._program.projects = []
         self._program.projects.extend(Project(atom) for atom in atoms)
 
     def external(self, atom: Atom, value: TruthValue) -> None:
-        '''
+        """
         Add an external statement to the ground representation.
 
         Parameters
@@ -877,11 +968,11 @@ class ProgramObserver(Observer):
             The external atom in form of a program literal.
         value
             The truth value of the external statement.
-        '''
+        """
         self._program.externals.append(External(atom, value))
 
     def assume(self, literals: Sequence[Literal]) -> None:
-        '''
+        """
         Extend the program with the given assumptions.
 
         Parameters
@@ -889,11 +980,13 @@ class ProgramObserver(Observer):
         literals
             The program literals to assume (positive literals are true and
             negative literals false for the next solve call).
-        '''
+        """
         self._program.assumptions.extend(literals)
 
-    def minimize(self, priority: Weight, literals: Sequence[Tuple[Literal, Weight]]) -> None:
-        '''
+    def minimize(
+        self, priority: Weight, literals: Sequence[Tuple[Literal, Weight]]
+    ) -> None:
+        """
         Add a minimize statement to the ground representation.
 
         Parameters
@@ -903,11 +996,11 @@ class ProgramObserver(Observer):
         literals
             List of weighted literals whose sum to minimize (pairs of literal
             and weight).
-        '''
+        """
         self._program.minimizes.append(Minimize(priority, literals))
 
     def acyc_edge(self, node_u: int, node_v: int, condition: Sequence[Literal]) -> None:
-        '''
+        """
         Add an edge statement to the gronud representation.
 
         Parameters
@@ -919,12 +1012,18 @@ class ProgramObserver(Observer):
         condition
             The list of program literals forming th condition under which to
             add the edge.
-        '''
+        """
         self._program.edges.append(Edge(node_u, node_v, condition))
 
-    def heuristic(self, atom: Atom, type_: HeuristicType, bias: Weight, priority: Weight,
-                  condition: Sequence[Literal]) -> None:
-        '''
+    def heuristic(
+        self,
+        atom: Atom,
+        type_: HeuristicType,
+        bias: Weight,
+        priority: Weight,
+        condition: Sequence[Literal],
+    ) -> None:
+        """
         Add heurisitic statement to the gronud representation.
 
         Parameters
@@ -939,5 +1038,7 @@ class ProgramObserver(Observer):
             An unsigned integer.
         condition
             List of program literals.
-        '''
-        self._program.heuristics.append(Heuristic(atom, type_, bias, priority, condition))
+        """
+        self._program.heuristics.append(
+            Heuristic(atom, type_, bias, priority, condition)
+        )

--- a/clingox/solving.py
+++ b/clingox/solving.py
@@ -1,7 +1,7 @@
-'''
+"""
 This module provides functions to approximate the cautious consequences of a
 program
-'''
+"""
 
 from typing import Optional, Sequence, Tuple
 
@@ -11,7 +11,7 @@ from clingo.symbol import Symbol
 
 
 def approximate(ctl: Control) -> Optional[Tuple[Sequence[Symbol], Sequence[Symbol]]]:
-    '''
+    """
     Approximate the stable models of a program.
 
     Parameters
@@ -32,7 +32,7 @@ def approximate(ctl: Control) -> Optional[Tuple[Sequence[Symbol], Sequence[Symbo
     -----
     Runs in polynomial time. An approximation might be returned even if the
     problem is unsatisfiable.
-    '''
+    """
     # solve with a limit of 0 conflicts to propagate direct consequences
     assert isinstance(ctl.configuration.solve, Configuration)
     solve_limit = ctl.configuration.solve.solve_limit

--- a/clingox/tests/__init__.py
+++ b/clingox/tests/__init__.py
@@ -1,3 +1,3 @@
-'''
+"""
 Unit tests for the clingox library.
-'''
+"""

--- a/clingox/tests/test_ast.py
+++ b/clingox/tests/test_ast.py
@@ -7,24 +7,51 @@ Simple tests for ast manipulation.
 from unittest import TestCase
 from typing import Callable, Container, List, Optional, Sequence, cast
 
+
 import clingo
 from clingo import Function
-from clingo.ast import AST, ASTType, Location, Position, Transformer, parse_string, Variable, Sign
+from clingo.ast import (
+    AST,
+    ASTType,
+    Location,
+    Position,
+    Transformer,
+    parse_string,
+    Variable,
+    Sign,
+)
 from .. import ast
 from ..ast import (
-    Arity, Associativity, TheoryTermParser, TheoryParser, TheoryAtomType,
-    ast_to_dict, dict_to_ast, location_to_str, prefix_symbolic_atoms, str_to_location, theory_parser_from_definition,
-    reify_symbolic_atoms, get_body)
+    Arity,
+    Associativity,
+    TheoryTermParser,
+    TheoryParser,
+    TheoryAtomType,
+    ast_to_dict,
+    dict_to_ast,
+    location_to_str,
+    prefix_symbolic_atoms,
+    str_to_location,
+    theory_parser_from_definition,
+    reify_symbolic_atoms,
+    get_body,
+)
 
-TERM_TABLE = {"t": {("-", Arity.Unary): (3, Associativity.NoAssociativity),
-                    ("**", Arity.Binary): (2, Associativity.Right),
-                    ("*", Arity.Binary): (1, Associativity.Left),
-                    ("+", Arity.Binary): (0, Associativity.Left),
-                    ("-", Arity.Binary): (0, Associativity.Left)}}
+TERM_TABLE = {
+    "t": {
+        ("-", Arity.Unary): (3, Associativity.NoAssociativity),
+        ("**", Arity.Binary): (2, Associativity.Right),
+        ("*", Arity.Binary): (1, Associativity.Left),
+        ("+", Arity.Binary): (0, Associativity.Left),
+        ("-", Arity.Binary): (0, Associativity.Left),
+    }
+}
 
-ATOM_TABLE = {("p", 0): (TheoryAtomType.Head, "t", None),
-              ("q", 1): (TheoryAtomType.Body, "t", None),
-              ("r", 0): (TheoryAtomType.Directive, "t", (["<"], "t"))}
+ATOM_TABLE = {
+    ("p", 0): (TheoryAtomType.Head, "t", None),
+    ("q", 1): (TheoryAtomType.Body, "t", None),
+    ("r", 0): (TheoryAtomType.Directive, "t", (["<"], "t")),
+}
 
 TEST_THEORY = """\
 #theory test {
@@ -41,14 +68,14 @@ TEST_THEORY = """\
 }\
 """
 
-LOC = Location(Position("a", 1, 2),
-               Position("a", 1, 2))
+LOC = Location(Position("a", 1, 2), Position("a", 1, 2))
 
 
 class Extractor(Transformer):
-    '''
+    """
     Simple visitor returning the first theory term in a program.
-    '''
+    """
+
     # pylint: disable=invalid-name
     atom: Optional[AST]
 
@@ -56,9 +83,9 @@ class Extractor(Transformer):
         self.atom = None
 
     def visit_TheoryAtom(self, x: AST):
-        '''
+        """
         Extract theory atom.
-        '''
+        """
         self.atom = x
         return x
 
@@ -97,7 +124,11 @@ def parse_term(s: str) -> str:
     """
     Parse the given theory term using a simple parse table for testing.
     """
-    return str(TheoryTermParser(TERM_TABLE["t"])(theory_atom(f"&p {{{s}}}").elements[0].terms[0]))
+    return str(
+        TheoryTermParser(TERM_TABLE["t"])(
+            theory_atom(f"&p {{{s}}}").elements[0].terms[0]
+        )
+    )
 
 
 def parse_atom(s: str, parser: Optional[TheoryParser] = None) -> str:
@@ -136,9 +167,9 @@ def parse_theory(s: str) -> TheoryParser:
 
 
 def parse_with(s: str, f: Callable[[AST], AST] = lambda x: x) -> Sequence[str]:
-    '''
+    """
     Parse the given program and apply the given function to it.
-    '''
+    """
     prg: List[str]
     prg = []
 
@@ -153,44 +184,48 @@ def parse_with(s: str, f: Callable[[AST], AST] = lambda x: x) -> Sequence[str]:
 
 
 def test_rename(s: str) -> Sequence[str]:
-    '''
+    """
     Parse the given program and rename symbolic atoms in it.
-    '''
+    """
     return parse_with(s, lambda s: prefix_symbolic_atoms(s, "u_"))
 
 
-def test_reify(s: str,
-               f: Callable[[AST], Sequence[AST]] = lambda x: [x],
-               st: bool = False
-               ) -> Sequence[str]:
-    '''
+def test_reify(
+    s: str, f: Callable[[AST], Sequence[AST]] = lambda x: [x], st: bool = False
+) -> Sequence[str]:
+    """
     Parse the given program and reify symbolic atoms in it.
-    '''
-    return parse_with(s, lambda x: reify_symbolic_atoms(x, 'u', f, st))
+    """
+    return parse_with(s, lambda x: reify_symbolic_atoms(x, "u", f, st))
 
 
 def test_ast_dict(tc: TestCase, s: str):
-    '''
+    """
     Parse and transform a program to its dictionary representation.
-    '''
+    """
     prg: list = []
     parse_string(s, prg.append)
     ret = [ast_to_dict(x) for x in prg]
-    preamble = {'ast_type': 'Program', 'location': '<string>:1:1', 'name': 'base', 'parameters': []}
+    preamble = {
+        "ast_type": "Program",
+        "location": "<string>:1:1",
+        "name": "base",
+        "parameters": [],
+    }
     tc.assertEqual(ret[0], preamble)
     tc.assertEqual(prg, [dict_to_ast(x) for x in ret])
     return ret[1:]
 
 
 class TestAST(TestCase):
-    '''
+    """
     Tests for AST manipulation.
-    '''
+    """
 
     def test_loc(self):
-        '''
+        """
         Test string representation of location.
-        '''
+        """
         loc = LOC
         self.assertEqual(location_to_str(loc), "a:1:2")
         self.assertEqual(str_to_location(location_to_str(loc)), loc)
@@ -200,19 +235,21 @@ class TestAST(TestCase):
         loc = Location(loc.begin, Position(loc.end.filename, 3, loc.end.column))
         self.assertEqual(location_to_str(loc), "a:1:2-3:4")
         self.assertEqual(str_to_location(location_to_str(loc)), loc)
-        loc = Location(loc.begin, Position('b', loc.end.line, loc.end.column))
+        loc = Location(loc.begin, Position("b", loc.end.line, loc.end.column))
         self.assertEqual(location_to_str(loc), "a:1:2-b:3:4")
         self.assertEqual(str_to_location(location_to_str(loc)), loc)
-        loc = Location(Position(r'a:1:2-3\:', loc.begin.line, loc.begin.column),
-                       Position('b:1:2-3', loc.end.line, loc.end.column))
-        self.assertEqual(location_to_str(loc), r'a\:1\:2-3\\\::1:2-b\:1\:2-3:3:4')
+        loc = Location(
+            Position(r"a:1:2-3\:", loc.begin.line, loc.begin.column),
+            Position("b:1:2-3", loc.end.line, loc.end.column),
+        )
+        self.assertEqual(location_to_str(loc), r"a\:1\:2-3\\\::1:2-b\:1\:2-3:3:4")
         self.assertEqual(str_to_location(location_to_str(loc)), loc)
-        self.assertRaises(RuntimeError, str_to_location, 'a:1:2-')
+        self.assertRaises(RuntimeError, str_to_location, "a:1:2-")
 
     def test_parse_term(self):
-        '''
+        """
         Test parsing of theory terms.
-        '''
+        """
         self.assertEqual(parse_term("1+2"), "+(1,2)")
         self.assertEqual(parse_term("1+2+3"), "+(+(1,2),3)")
         self.assertEqual(parse_term("1+2*3"), "+(1,*(2,3))")
@@ -222,15 +259,15 @@ class TestAST(TestCase):
         self.assertRaises(RuntimeError, parse_term, "1++2")
 
     def test_parse_atom(self):
-        '''
+        """
         Test parsing of theory atoms.
-        '''
+        """
         self.assertEqual(parse_atom("&p {1+2}"), "&p { +(1,2) }")
         self.assertEqual(parse_atom("&p {1+2+3}"), "&p { +(+(1,2),3) }")
         self.assertEqual(parse_atom("&q(1+2+3) { }"), "&q(((1+2)+3)) { }")
         self.assertEqual(parse_atom("&r { } < 1+2+3"), "&r { } < +(+(1,2),3)")
         # for coverage
-        p = TheoryParser({'t': TheoryTermParser(TERM_TABLE["t"])}, ATOM_TABLE)
+        p = TheoryParser({"t": TheoryTermParser(TERM_TABLE["t"])}, ATOM_TABLE)
         self.assertEqual(parse_atom("&p {1+2}", p), "&p { +(1,2) }")
 
     def test_parse_atom_occ(self):
@@ -265,10 +302,16 @@ class TestAST(TestCase):
         self.assertEqual(prwp("&p {1+2}."), "&p { +(1,2) }.")
         self.assertEqual(prwp("#show x : &q(0) {1+2}."), "#show x : &q(0) { +(1,2) }.")
         self.assertEqual(prwp(":~ &q(0) {1+2}. [0]"), ":~ &q(0) { +(1,2) }. [0@0]")
-        self.assertEqual(prwp("#edge (u, v) : &q(0) {1+2}."), "#edge (u,v) : &q(0) { +(1,2) }.")
-        self.assertEqual(prwp("#heuristic a : &q(0) {1+2}. [sign,true]"),
-                         "#heuristic a : &q(0) { +(1,2) }. [sign@0,true]")
-        self.assertEqual(prwp("#project a : &q(0) {1+2}."), "#project a : &q(0) { +(1,2) }.")
+        self.assertEqual(
+            prwp("#edge (u, v) : &q(0) {1+2}."), "#edge (u,v) : &q(0) { +(1,2) }."
+        )
+        self.assertEqual(
+            prwp("#heuristic a : &q(0) {1+2}. [sign,true]"),
+            "#heuristic a : &q(0) { +(1,2) }. [sign@0,true]",
+        )
+        self.assertEqual(
+            prwp("#project a : &q(0) {1+2}."), "#project a : &q(0) { +(1,2) }."
+        )
         self.assertRaises(RuntimeError, prwp, ":- &p {1+2}.")
         self.assertRaises(RuntimeError, prwp, "&q(1+2+3) { }.")
         self.assertEqual(prwp(":- &q(1+2+3) { }."), "#false :- &q(((1+2)+3)) { }.")
@@ -280,884 +323,2267 @@ class TestAST(TestCase):
         self.assertRaises(RuntimeError, prwp, "&r { } <= 3.")
 
     def test_rename(self):
-        '''
+        """
         Test renaming symbolic atoms.
-        '''
+        """
         self.assertEqual(
             test_rename("a :- b(X,Y), not c(f(3,b))."),
-            ['#program base.', 'u_a :- u_b(X,Y); not u_c(f(3,b)).'])
+            ["#program base.", "u_a :- u_b(X,Y); not u_c(f(3,b))."],
+        )
         sym = clingo.ast.SymbolicAtom(
-            clingo.ast.UnaryOperation(LOC, clingo.ast.UnaryOperator.Minus,
-                                      clingo.ast.Function(LOC, 'a', [], 0)))
-        self.assertEqual(
-            str(prefix_symbolic_atoms(sym, 'u_')),
-            '-u_a')
+            clingo.ast.UnaryOperation(
+                LOC,
+                clingo.ast.UnaryOperator.Minus,
+                clingo.ast.Function(LOC, "a", [], 0),
+            )
+        )
+        self.assertEqual(str(prefix_symbolic_atoms(sym, "u_")), "-u_a")
         self.assertEqual(
             test_rename("-a :- -b(X,Y), not -c(f(3,b))."),
-            ['#program base.', '-u_a :- -u_b(X,Y); not -u_c(f(3,b)).'])
-        sym = ast.SymbolicAtom(ast.SymbolicTerm(LOC, Function('a', [Function('b')])))
-        self.assertEqual(
-            str(prefix_symbolic_atoms(sym, 'u_')),
-            'u_a(b)')
-        sym = ast.SymbolicAtom(Variable(LOC, 'B'))
-        self.assertEqual(
-            prefix_symbolic_atoms(sym, 'u'),
-            sym)
+            ["#program base.", "-u_a :- -u_b(X,Y); not -u_c(f(3,b))."],
+        )
+        sym = ast.SymbolicAtom(ast.SymbolicTerm(LOC, Function("a", [Function("b")])))
+        self.assertEqual(str(prefix_symbolic_atoms(sym, "u_")), "u_a(b)")
+        sym = ast.SymbolicAtom(Variable(LOC, "B"))
+        self.assertEqual(prefix_symbolic_atoms(sym, "u"), sym)
 
     def test_reify(self):
-        '''
+        """
         Test reifying symbolic atoms.
-        '''
-        self.assertEqual(
-            test_reify("a."),
-            ['#program base.', 'u(a).'])
+        """
+        self.assertEqual(test_reify("a."), ["#program base.", "u(a)."])
         self.assertEqual(
             test_reify("a :- b(X,Y), not c(f(3,b))."),
-            ['#program base.', 'u(a) :- u(b(X,Y)); not u(c(f(3,b))).'])
+            ["#program base.", "u(a) :- u(b(X,Y)); not u(c(f(3,b)))."],
+        )
         sym = clingo.ast.SymbolicAtom(
-            clingo.ast.UnaryOperation(LOC, clingo.ast.UnaryOperator.Minus,
-                                      clingo.ast.Function(LOC, 'a', [], 0)))
+            clingo.ast.UnaryOperation(
+                LOC,
+                clingo.ast.UnaryOperator.Minus,
+                clingo.ast.Function(LOC, "a", [], 0),
+            )
+        )
+        self.assertEqual(str(reify_symbolic_atoms(sym, "u")), "-u(a)")
         self.assertEqual(
-            str(reify_symbolic_atoms(sym, 'u')),
-            '-u(a)')
-        self.assertEqual(
-            str(reify_symbolic_atoms(sym, 'u', reify_strong_negation=True)),
-            'u(-a)')
+            str(reify_symbolic_atoms(sym, "u", reify_strong_negation=True)), "u(-a)"
+        )
         self.assertEqual(
             test_reify("-a :- -b(X,Y), not -c(f(3,b))."),
-            ['#program base.', '-u(a) :- -u(b(X,Y)); not -u(c(f(3,b))).'])
+            ["#program base.", "-u(a) :- -u(b(X,Y)); not -u(c(f(3,b)))."],
+        )
         self.assertEqual(
-            test_reify("-a :- b(X,Y), not -c(f(3,b)). a :- -b(X,Y), not c(f(3,b)).", st=True),
-            ['#program base.', 'u(-a) :- u(b(X,Y)); not u(-c(f(3,b))).', 'u(a) :- u(-b(X,Y)); not u(c(f(3,b))).'])
+            test_reify(
+                "-a :- b(X,Y), not -c(f(3,b)). a :- -b(X,Y), not c(f(3,b)).", st=True
+            ),
+            [
+                "#program base.",
+                "u(-a) :- u(b(X,Y)); not u(-c(f(3,b))).",
+                "u(a) :- u(-b(X,Y)); not u(c(f(3,b))).",
+            ],
+        )
         self.assertEqual(
-            test_reify("a :- b(X,Y), not c(f(3,b)).", f=lambda x: [x, Variable(LOC, 'T'), Variable(LOC, 'I')]),
-            ['#program base.', 'u(a,T,I) :- u(b(X,Y),T,I); not u(c(f(3,b)),T,I).'])
+            test_reify(
+                "a :- b(X,Y), not c(f(3,b)).",
+                f=lambda x: [x, Variable(LOC, "T"), Variable(LOC, "I")],
+            ),
+            ["#program base.", "u(a,T,I) :- u(b(X,Y),T,I); not u(c(f(3,b)),T,I)."],
+        )
         self.assertEqual(
             test_reify("-a :- -b(X,Y), &theory(X){ p(X): q(X), -r(X) }."),
-            ['#program base.', '-u(a) :- -u(b(X,Y)); &theory(X) { p(X): u(q(X)), -u(r(X)) }.'])
+            [
+                "#program base.",
+                "-u(a) :- -u(b(X,Y)); &theory(X) { p(X): u(q(X)), -u(r(X)) }.",
+            ],
+        )
         self.assertEqual(
             test_reify("-a :- -b(X,Y), &theory(X){ p(X): q(X), not r(X) }."),
-            ['#program base.', '-u(a) :- -u(b(X,Y)); &theory(X) { p(X): u(q(X)), not u(r(X)) }.'])
+            [
+                "#program base.",
+                "-u(a) :- -u(b(X,Y)); &theory(X) { p(X): u(q(X)), not u(r(X)) }.",
+            ],
+        )
 
         def fun(x):
-            return [Variable(LOC, 'T'), x, Variable(LOC, 'I')]
+            return [Variable(LOC, "T"), x, Variable(LOC, "I")]
 
         self.assertEqual(
             test_reify("a :- -b(X,Y), not c(f(3,b)).", f=fun, st=True),
-            ['#program base.', 'u(T,a,I) :- u(T,-b(X,Y),I); not u(T,c(f(3,b)),I).'])
+            ["#program base.", "u(T,a,I) :- u(T,-b(X,Y),I); not u(T,c(f(3,b)),I)."],
+        )
 
         self.assertEqual(
             test_reify("a :- -b(X,Y), not c(f(3,b)).", f=fun, st=True),
-            ['#program base.', 'u(T,a,I) :- u(T,-b(X,Y),I); not u(T,c(f(3,b)),I).'])
+            ["#program base.", "u(T,a,I) :- u(T,-b(X,Y),I); not u(T,c(f(3,b)),I)."],
+        )
 
-        sym = ast.SymbolicAtom(ast.SymbolicTerm(LOC, Function('a', [Function('b')])))
-        self.assertEqual(
-            str(reify_symbolic_atoms(sym, 'u')),
-            'u(a(b))')
-        sym = ast.SymbolicAtom(Variable(LOC, 'B'))
-        self.assertEqual(
-            prefix_symbolic_atoms(sym, 'u'),
-            sym)
+        sym = ast.SymbolicAtom(ast.SymbolicTerm(LOC, Function("a", [Function("b")])))
+        self.assertEqual(str(reify_symbolic_atoms(sym, "u")), "u(a(b))")
+        sym = ast.SymbolicAtom(Variable(LOC, "B"))
+        self.assertEqual(prefix_symbolic_atoms(sym, "u"), sym)
 
     def test_encode_term(self):
-        '''
+        """
         Test encoding of terms in AST.
-        '''
+        """
         self.assertEqual(
-            test_ast_dict(self, 'a(1).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-6',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-5', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-5', 'name': 'a',
-                                           'arguments': [{'ast_type': 'SymbolicTerm', 'location': '<string>:1:3-4',
-                                                          'symbol': '1'}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(1)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-6",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-5",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-5",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "SymbolicTerm",
+                                        "location": "<string>:1:3-4",
+                                        "symbol": "1",
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(X).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-6',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-5', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-5', 'name': 'a',
-                                           'arguments': [{'ast_type': 'Variable', 'location': '<string>:1:3-4',
-                                                          'name': 'X'}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(X)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-6",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-5",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-5",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "Variable",
+                                        "location": "<string>:1:3-4",
+                                        "name": "X",
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(-1).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-7',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-6', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-6', 'name': 'a',
-                                           'arguments': [{'ast_type': 'UnaryOperation', 'location': '<string>:1:3-5',
-                                                          'operator_type': 0,
-                                                          'argument': {'ast_type': 'SymbolicTerm',
-                                                                       'location': '<string>:1:4-5', 'symbol': '1'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(-1)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-7",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-6",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-6",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "UnaryOperation",
+                                        "location": "<string>:1:3-5",
+                                        "operator_type": 0,
+                                        "argument": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:4-5",
+                                            "symbol": "1",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(~1).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-7',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-6', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-6', 'name': 'a',
-                                           'arguments': [{'ast_type': 'UnaryOperation', 'location': '<string>:1:3-5',
-                                                          'operator_type': 1,
-                                                          'argument': {'ast_type': 'SymbolicTerm',
-                                                                       'location': '<string>:1:4-5', 'symbol': '1'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(~1)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-7",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-6",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-6",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "UnaryOperation",
+                                        "location": "<string>:1:3-5",
+                                        "operator_type": 1,
+                                        "argument": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:4-5",
+                                            "symbol": "1",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(|1|).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-7', 'name': 'a',
-                                           'arguments': [{'ast_type': 'UnaryOperation', 'location': '<string>:1:3-6',
-                                                          'operator_type': 2,
-                                                          'argument': {'ast_type': 'SymbolicTerm',
-                                                                       'location': '<string>:1:4-5', 'symbol': '1'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(|1|)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-7",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "UnaryOperation",
+                                        "location": "<string>:1:3-6",
+                                        "operator_type": 2,
+                                        "argument": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:4-5",
+                                            "symbol": "1",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(1+2).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-7', 'name': 'a',
-                                           'arguments': [{'ast_type': 'BinaryOperation', 'location': '<string>:1:3-6',
-                                                          'operator_type': 3,
-                                                          'left': {'ast_type': 'SymbolicTerm',
-                                                                   'location': '<string>:1:3-4', 'symbol': '1'},
-                                                          'right': {'ast_type': 'SymbolicTerm',
-                                                                    'location': '<string>:1:5-6', 'symbol': '2'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(1+2)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-7",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "BinaryOperation",
+                                        "location": "<string>:1:3-6",
+                                        "operator_type": 3,
+                                        "left": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:3-4",
+                                            "symbol": "1",
+                                        },
+                                        "right": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:5-6",
+                                            "symbol": "2",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(1-2).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-7', 'name': 'a',
-                                           'arguments': [{'ast_type': 'BinaryOperation', 'location': '<string>:1:3-6',
-                                                          'operator_type': 4,
-                                                          'left': {'ast_type': 'SymbolicTerm',
-                                                                   'location': '<string>:1:3-4', 'symbol': '1'},
-                                                          'right': {'ast_type': 'SymbolicTerm',
-                                                                    'location': '<string>:1:5-6', 'symbol': '2'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(1-2)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-7",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "BinaryOperation",
+                                        "location": "<string>:1:3-6",
+                                        "operator_type": 4,
+                                        "left": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:3-4",
+                                            "symbol": "1",
+                                        },
+                                        "right": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:5-6",
+                                            "symbol": "2",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(1*2).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-7', 'name': 'a',
-                                           'arguments': [{'ast_type': 'BinaryOperation', 'location': '<string>:1:3-6',
-                                                          'operator_type': 5,
-                                                          'left': {'ast_type': 'SymbolicTerm',
-                                                                   'location': '<string>:1:3-4', 'symbol': '1'},
-                                                          'right': {'ast_type': 'SymbolicTerm',
-                                                                    'location': '<string>:1:5-6', 'symbol': '2'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(1*2)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-7",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "BinaryOperation",
+                                        "location": "<string>:1:3-6",
+                                        "operator_type": 5,
+                                        "left": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:3-4",
+                                            "symbol": "1",
+                                        },
+                                        "right": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:5-6",
+                                            "symbol": "2",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(1/2).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-7', 'name': 'a',
-                                           'arguments': [{'ast_type': 'BinaryOperation', 'location': '<string>:1:3-6',
-                                                          'operator_type': 6,
-                                                          'left': {'ast_type': 'SymbolicTerm',
-                                                                   'location': '<string>:1:3-4', 'symbol': '1'},
-                                                          'right': {'ast_type': 'SymbolicTerm',
-                                                                    'location': '<string>:1:5-6', 'symbol': '2'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(1/2)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-7",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "BinaryOperation",
+                                        "location": "<string>:1:3-6",
+                                        "operator_type": 6,
+                                        "left": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:3-4",
+                                            "symbol": "1",
+                                        },
+                                        "right": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:5-6",
+                                            "symbol": "2",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(1\\2).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-7', 'name': 'a',
-                                           'arguments': [{'ast_type': 'BinaryOperation', 'location': '<string>:1:3-6',
-                                                          'operator_type': 7,
-                                                          'left': {'ast_type': 'SymbolicTerm',
-                                                                   'location': '<string>:1:3-4', 'symbol': '1'},
-                                                          'right': {'ast_type': 'SymbolicTerm',
-                                                                    'location': '<string>:1:5-6', 'symbol': '2'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(1\\2)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-7",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "BinaryOperation",
+                                        "location": "<string>:1:3-6",
+                                        "operator_type": 7,
+                                        "left": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:3-4",
+                                            "symbol": "1",
+                                        },
+                                        "right": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:5-6",
+                                            "symbol": "2",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(1**2).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-9',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-8', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-8', 'name': 'a',
-                                           'arguments': [{'ast_type': 'BinaryOperation', 'location': '<string>:1:3-7',
-                                                          'operator_type': 8,
-                                                          'left': {'ast_type': 'SymbolicTerm',
-                                                                   'location': '<string>:1:3-4', 'symbol': '1'},
-                                                          'right': {'ast_type': 'SymbolicTerm',
-                                                                    'location': '<string>:1:6-7', 'symbol': '2'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(1**2)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-9",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-8",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-8",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "BinaryOperation",
+                                        "location": "<string>:1:3-7",
+                                        "operator_type": 8,
+                                        "left": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:3-4",
+                                            "symbol": "1",
+                                        },
+                                        "right": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:6-7",
+                                            "symbol": "2",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(1^2).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-7', 'name': 'a',
-                                           'arguments': [{'ast_type': 'BinaryOperation', 'location': '<string>:1:3-6',
-                                                          'operator_type': 0,
-                                                          'left': {'ast_type': 'SymbolicTerm',
-                                                                   'location': '<string>:1:3-4', 'symbol': '1'},
-                                                          'right': {'ast_type': 'SymbolicTerm',
-                                                                    'location': '<string>:1:5-6', 'symbol': '2'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(1^2)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-7",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "BinaryOperation",
+                                        "location": "<string>:1:3-6",
+                                        "operator_type": 0,
+                                        "left": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:3-4",
+                                            "symbol": "1",
+                                        },
+                                        "right": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:5-6",
+                                            "symbol": "2",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(1?2).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-7', 'name': 'a',
-                                           'arguments': [{'ast_type': 'BinaryOperation', 'location': '<string>:1:3-6',
-                                                          'operator_type': 1,
-                                                          'left': {'ast_type': 'SymbolicTerm',
-                                                                   'location': '<string>:1:3-4', 'symbol': '1'},
-                                                          'right': {'ast_type': 'SymbolicTerm',
-                                                                    'location': '<string>:1:5-6', 'symbol': '2'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(1?2)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-7",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "BinaryOperation",
+                                        "location": "<string>:1:3-6",
+                                        "operator_type": 1,
+                                        "left": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:3-4",
+                                            "symbol": "1",
+                                        },
+                                        "right": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:5-6",
+                                            "symbol": "2",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(1&2).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-7', 'name': 'a',
-                                           'arguments': [{'ast_type': 'BinaryOperation', 'location': '<string>:1:3-6',
-                                                          'operator_type': 2,
-                                                          'left': {'ast_type': 'SymbolicTerm',
-                                                                   'location': '<string>:1:3-4', 'symbol': '1'},
-                                                          'right': {'ast_type': 'SymbolicTerm',
-                                                                    'location': '<string>:1:5-6', 'symbol': '2'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(1&2)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-7",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "BinaryOperation",
+                                        "location": "<string>:1:3-6",
+                                        "operator_type": 2,
+                                        "left": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:3-4",
+                                            "symbol": "1",
+                                        },
+                                        "right": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:5-6",
+                                            "symbol": "2",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(1..2).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-9',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-8', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-8', 'name': 'a',
-                                           'arguments': [{'ast_type': 'Interval', 'location': '<string>:1:3-7',
-                                                          'left': {'ast_type': 'SymbolicTerm',
-                                                                   'location': '<string>:1:3-4', 'symbol': '1'},
-                                                          'right': {'ast_type': 'SymbolicTerm',
-                                                                    'location': '<string>:1:6-7', 'symbol': '2'}}],
-                                           'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a(1..2)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-9",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-8",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-8",
+                                "name": "a",
+                                "arguments": [
+                                    {
+                                        "ast_type": "Interval",
+                                        "location": "<string>:1:3-7",
+                                        "left": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:3-4",
+                                            "symbol": "1",
+                                        },
+                                        "right": {
+                                            "ast_type": "SymbolicTerm",
+                                            "location": "<string>:1:6-7",
+                                            "symbol": "2",
+                                        },
+                                    }
+                                ],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a(1;2).'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Pool', 'location': '<string>:1:1-7',
-                                           'arguments': [{'ast_type': 'Function', 'location': '<string>:1:1-7',
-                                                          'name': 'a',
-                                                          'arguments': [{'ast_type': 'SymbolicTerm',
-                                                                         'location': '<string>:1:3-4', 'symbol': '1'}],
-                                                          'external': 0},
-                                                         {'ast_type': 'Function', 'location': '<string>:1:1-7',
-                                                          'name': 'a',
-                                                          'arguments': [{'ast_type': 'SymbolicTerm',
-                                                                         'location': '<string>:1:5-6', 'symbol': '2'}],
-                                                          'external': 0}]}}},
-              'body': []}])
+            test_ast_dict(self, "a(1;2)."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Pool",
+                                "location": "<string>:1:1-7",
+                                "arguments": [
+                                    {
+                                        "ast_type": "Function",
+                                        "location": "<string>:1:1-7",
+                                        "name": "a",
+                                        "arguments": [
+                                            {
+                                                "ast_type": "SymbolicTerm",
+                                                "location": "<string>:1:3-4",
+                                                "symbol": "1",
+                                            }
+                                        ],
+                                        "external": 0,
+                                    },
+                                    {
+                                        "ast_type": "Function",
+                                        "location": "<string>:1:1-7",
+                                        "name": "a",
+                                        "arguments": [
+                                            {
+                                                "ast_type": "SymbolicTerm",
+                                                "location": "<string>:1:5-6",
+                                                "symbol": "2",
+                                            }
+                                        ],
+                                        "external": 0,
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
 
     def test_encode_literal(self):
-        '''
+        """
         Tests for converting between python and ast representation of literals.
-        '''
+        """
         # Note: tests are simply skipped for older clingo versions
         if clingo.version() < (5, 6, 0):
             return  # nocoverage
         self.assertEqual(
-            test_ast_dict(self, 'a.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-3',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-2', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-2', 'name': 'a',
-                                           'arguments': [], 'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "a."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-3",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-2",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-2",
+                                "name": "a",
+                                "arguments": [],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'not a.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-7',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-6', 'sign': 1,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:5-6', 'name': 'a',
-                                           'arguments': [], 'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "not a."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-7",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-6",
+                        "sign": 1,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:5-6",
+                                "name": "a",
+                                "arguments": [],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'not not a.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-11',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-10', 'sign': 2,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:9-10', 'name': 'a',
-                                           'arguments': [], 'external': 0}}},
-              'body': []}])
+            test_ast_dict(self, "not not a."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-11",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-10",
+                        "sign": 2,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:9-10",
+                                "name": "a",
+                                "arguments": [],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a <= b.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'Comparison',
-                                'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:1-2', 'symbol': 'a'},
-                                'guards': [{'ast_type': 'Guard', 'comparison': 2,
-                                            'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:6-7',
-                                                     'symbol': 'b'}}]}},
-              'body': []}]
-            )
+            test_ast_dict(self, "a <= b."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "Comparison",
+                            "term": {
+                                "ast_type": "SymbolicTerm",
+                                "location": "<string>:1:1-2",
+                                "symbol": "a",
+                            },
+                            "guards": [
+                                {
+                                    "ast_type": "Guard",
+                                    "comparison": 2,
+                                    "term": {
+                                        "ast_type": "SymbolicTerm",
+                                        "location": "<string>:1:6-7",
+                                        "symbol": "b",
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a < b.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-7',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-6', 'sign': 0,
-                       'atom': {'ast_type': 'Comparison',
-                                'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:1-2', 'symbol': 'a'},
-                                'guards': [{'ast_type': 'Guard', 'comparison': 1,
-                                            'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:5-6',
-                                                     'symbol': 'b'}}]}},
-              'body': []}])
+            test_ast_dict(self, "a < b."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-7",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-6",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "Comparison",
+                            "term": {
+                                "ast_type": "SymbolicTerm",
+                                "location": "<string>:1:1-2",
+                                "symbol": "a",
+                            },
+                            "guards": [
+                                {
+                                    "ast_type": "Guard",
+                                    "comparison": 1,
+                                    "term": {
+                                        "ast_type": "SymbolicTerm",
+                                        "location": "<string>:1:5-6",
+                                        "symbol": "b",
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a >= b.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'Comparison',
-                                'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:1-2', 'symbol': 'a'},
-                                'guards': [{'ast_type': 'Guard', 'comparison': 3,
-                                            'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:6-7',
-                                                     'symbol': 'b'}}]}},
-              'body': []}])
+            test_ast_dict(self, "a >= b."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "Comparison",
+                            "term": {
+                                "ast_type": "SymbolicTerm",
+                                "location": "<string>:1:1-2",
+                                "symbol": "a",
+                            },
+                            "guards": [
+                                {
+                                    "ast_type": "Guard",
+                                    "comparison": 3,
+                                    "term": {
+                                        "ast_type": "SymbolicTerm",
+                                        "location": "<string>:1:6-7",
+                                        "symbol": "b",
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a > b.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-7',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-6', 'sign': 0,
-                       'atom': {'ast_type': 'Comparison',
-                                'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:1-2', 'symbol': 'a'},
-                                'guards': [{'ast_type': 'Guard', 'comparison': 0,
-                                            'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:5-6',
-                                                     'symbol': 'b'}}]}},
-              'body': []}])
+            test_ast_dict(self, "a > b."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-7",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-6",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "Comparison",
+                            "term": {
+                                "ast_type": "SymbolicTerm",
+                                "location": "<string>:1:1-2",
+                                "symbol": "a",
+                            },
+                            "guards": [
+                                {
+                                    "ast_type": "Guard",
+                                    "comparison": 0,
+                                    "term": {
+                                        "ast_type": "SymbolicTerm",
+                                        "location": "<string>:1:5-6",
+                                        "symbol": "b",
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a = b.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-7',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-6', 'sign': 0,
-                       'atom': {'ast_type': 'Comparison',
-                                'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:1-2', 'symbol': 'a'},
-                                'guards': [{'ast_type': 'Guard', 'comparison': 5,
-                                            'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:5-6',
-                                                     'symbol': 'b'}}]}},
-              'body': []}])
+            test_ast_dict(self, "a = b."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-7",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-6",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "Comparison",
+                            "term": {
+                                "ast_type": "SymbolicTerm",
+                                "location": "<string>:1:1-2",
+                                "symbol": "a",
+                            },
+                            "guards": [
+                                {
+                                    "ast_type": "Guard",
+                                    "comparison": 5,
+                                    "term": {
+                                        "ast_type": "SymbolicTerm",
+                                        "location": "<string>:1:5-6",
+                                        "symbol": "b",
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a != b.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-7', 'sign': 0,
-                       'atom': {'ast_type': 'Comparison',
-                                'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:1-2', 'symbol': 'a'},
-                                'guards': [{'ast_type': 'Guard', 'comparison': 4,
-                                            'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:6-7',
-                                                     'symbol': 'b'}}]}},
-              'body': []}])
+            test_ast_dict(self, "a != b."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-7",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "Comparison",
+                            "term": {
+                                "ast_type": "SymbolicTerm",
+                                "location": "<string>:1:1-2",
+                                "symbol": "a",
+                            },
+                            "guards": [
+                                {
+                                    "ast_type": "Guard",
+                                    "comparison": 4,
+                                    "term": {
+                                        "ast_type": "SymbolicTerm",
+                                        "location": "<string>:1:6-7",
+                                        "symbol": "b",
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, 'a : b.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-7',
-              'head': {'ast_type': 'Disjunction', 'location': '<string>:1:1-6',
-                       'elements': [{'ast_type': 'ConditionalLiteral', 'location': '<string>:1:1-2',
-                                     'literal': {'ast_type': 'Literal', 'location': '<string>:1:1-2', 'sign': 0,
-                                                 'atom': {'ast_type': 'SymbolicAtom',
-                                                          'symbol': {'ast_type': 'Function',
-                                                                     'location': '<string>:1:1-2', 'name': 'a',
-                                                                     'arguments': [], 'external': 0}}},
-                                     'condition': [{'ast_type': 'Literal', 'location': '<string>:1:5-6', 'sign': 0,
-                                                    'atom': {'ast_type': 'SymbolicAtom',
-                                                             'symbol': {'ast_type': 'Function',
-                                                                        'location': '<string>:1:5-6', 'name': 'b',
-                                                                        'arguments': [], 'external': 0}}}]}]},
-              'body': []}])
+            test_ast_dict(self, "a : b."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-7",
+                    "head": {
+                        "ast_type": "Disjunction",
+                        "location": "<string>:1:1-6",
+                        "elements": [
+                            {
+                                "ast_type": "ConditionalLiteral",
+                                "location": "<string>:1:1-2",
+                                "literal": {
+                                    "ast_type": "Literal",
+                                    "location": "<string>:1:1-2",
+                                    "sign": 0,
+                                    "atom": {
+                                        "ast_type": "SymbolicAtom",
+                                        "symbol": {
+                                            "ast_type": "Function",
+                                            "location": "<string>:1:1-2",
+                                            "name": "a",
+                                            "arguments": [],
+                                            "external": 0,
+                                        },
+                                    },
+                                },
+                                "condition": [
+                                    {
+                                        "ast_type": "Literal",
+                                        "location": "<string>:1:5-6",
+                                        "sign": 0,
+                                        "atom": {
+                                            "ast_type": "SymbolicAtom",
+                                            "symbol": {
+                                                "ast_type": "Function",
+                                                "location": "<string>:1:5-6",
+                                                "name": "b",
+                                                "arguments": [],
+                                                "external": 0,
+                                            },
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, ':- a : b.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-10',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-10', 'sign': 0,
-                       'atom': {'ast_type': 'BooleanConstant', 'value': 0}},
-              'body': [{'ast_type': 'ConditionalLiteral', 'location': '<string>:1:4-9',
-                        'literal': {'ast_type': 'Literal', 'location': '<string>:1:4-5', 'sign': 0,
-                                    'atom': {'ast_type': 'SymbolicAtom',
-                                             'symbol': {'ast_type': 'Function', 'location': '<string>:1:4-5',
-                                                        'name': 'a', 'arguments': [], 'external': 0}}},
-                        'condition': [{'ast_type': 'Literal', 'location': '<string>:1:8-9', 'sign': 0,
-                                       'atom': {'ast_type': 'SymbolicAtom',
-                                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:8-9',
-                                                           'name': 'b', 'arguments': [], 'external': 0}}}]}]}])
+            test_ast_dict(self, ":- a : b."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-10",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-10",
+                        "sign": 0,
+                        "atom": {"ast_type": "BooleanConstant", "value": 0},
+                    },
+                    "body": [
+                        {
+                            "ast_type": "ConditionalLiteral",
+                            "location": "<string>:1:4-9",
+                            "literal": {
+                                "ast_type": "Literal",
+                                "location": "<string>:1:4-5",
+                                "sign": 0,
+                                "atom": {
+                                    "ast_type": "SymbolicAtom",
+                                    "symbol": {
+                                        "ast_type": "Function",
+                                        "location": "<string>:1:4-5",
+                                        "name": "a",
+                                        "arguments": [],
+                                        "external": 0,
+                                    },
+                                },
+                            },
+                            "condition": [
+                                {
+                                    "ast_type": "Literal",
+                                    "location": "<string>:1:8-9",
+                                    "sign": 0,
+                                    "atom": {
+                                        "ast_type": "SymbolicAtom",
+                                        "symbol": {
+                                            "ast_type": "Function",
+                                            "location": "<string>:1:8-9",
+                                            "name": "b",
+                                            "arguments": [],
+                                            "external": 0,
+                                        },
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#sum {1:a:b} <= 2.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-19',
-              'head': {'ast_type': 'HeadAggregate', 'location': '<string>:1:1-18',
-                       'left_guard': {'ast_type': 'Guard', 'comparison': 3,
-                                      'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:17-18',
-                                               'symbol': '2'}},
-                       'function': 1,
-                       'elements': [{'ast_type': 'HeadAggregateElement',
-                                     'terms': [{'ast_type': 'SymbolicTerm', 'location': '<string>:1:7-8',
-                                                'symbol': '1'}],
-                                     'condition': {'ast_type': 'ConditionalLiteral', 'location': '<string>:1:9-10',
-                                                   'literal': {'ast_type': 'Literal', 'location': '<string>:1:9-10',
-                                                               'sign': 0,
-                                                               'atom': {'ast_type': 'SymbolicAtom',
-                                                                        'symbol': {'ast_type': 'Function',
-                                                                                   'location': '<string>:1:9-10',
-                                                                                   'name': 'a', 'arguments': [],
-                                                                                   'external': 0}}},
-                                                   'condition': [{'ast_type': 'Literal', 'location': '<string>:1:11-12',
-                                                                  'sign': 0,
-                                                                  'atom': {'ast_type': 'SymbolicAtom',
-                                                                           'symbol': {'ast_type': 'Function',
-                                                                                      'location': '<string>:1:11-12',
-                                                                                      'name': 'b', 'arguments': [],
-                                                                                      'external': 0}}}]}}],
-                       'right_guard': None},
-              'body': []}])
+            test_ast_dict(self, "#sum {1:a:b} <= 2."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-19",
+                    "head": {
+                        "ast_type": "HeadAggregate",
+                        "location": "<string>:1:1-18",
+                        "left_guard": {
+                            "ast_type": "Guard",
+                            "comparison": 3,
+                            "term": {
+                                "ast_type": "SymbolicTerm",
+                                "location": "<string>:1:17-18",
+                                "symbol": "2",
+                            },
+                        },
+                        "function": 1,
+                        "elements": [
+                            {
+                                "ast_type": "HeadAggregateElement",
+                                "terms": [
+                                    {
+                                        "ast_type": "SymbolicTerm",
+                                        "location": "<string>:1:7-8",
+                                        "symbol": "1",
+                                    }
+                                ],
+                                "condition": {
+                                    "ast_type": "ConditionalLiteral",
+                                    "location": "<string>:1:9-10",
+                                    "literal": {
+                                        "ast_type": "Literal",
+                                        "location": "<string>:1:9-10",
+                                        "sign": 0,
+                                        "atom": {
+                                            "ast_type": "SymbolicAtom",
+                                            "symbol": {
+                                                "ast_type": "Function",
+                                                "location": "<string>:1:9-10",
+                                                "name": "a",
+                                                "arguments": [],
+                                                "external": 0,
+                                            },
+                                        },
+                                    },
+                                    "condition": [
+                                        {
+                                            "ast_type": "Literal",
+                                            "location": "<string>:1:11-12",
+                                            "sign": 0,
+                                            "atom": {
+                                                "ast_type": "SymbolicAtom",
+                                                "symbol": {
+                                                    "ast_type": "Function",
+                                                    "location": "<string>:1:11-12",
+                                                    "name": "b",
+                                                    "arguments": [],
+                                                    "external": 0,
+                                                },
+                                            },
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                        "right_guard": None,
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, ':- #sum {1:b} <= 2.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-20',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-20', 'sign': 0,
-                       'atom': {'ast_type': 'BooleanConstant', 'value': 0}},
-              'body': [{'ast_type': 'Literal', 'location': '<string>:1:4-19', 'sign': 0,
-                        'atom': {'ast_type': 'BodyAggregate', 'location': '<string>:1:4-19',
-                                 'left_guard': {'ast_type': 'Guard', 'comparison': 3,
-                                                'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:18-19',
-                                                         'symbol': '2'}},
-                                 'function': 1,
-                                 'elements': [{'ast_type': 'BodyAggregateElement',
-                                               'terms': [{'ast_type': 'SymbolicTerm', 'location': '<string>:1:10-11',
-                                                          'symbol': '1'}],
-                                               'condition': [{'ast_type': 'Literal', 'location': '<string>:1:12-13',
-                                                              'sign': 0,
-                                                              'atom': {'ast_type': 'SymbolicAtom',
-                                                                       'symbol': {'ast_type': 'Function',
-                                                                                  'location': '<string>:1:12-13',
-                                                                                  'name': 'b', 'arguments': [],
-                                                                                  'external': 0}}}]}],
-                                 'right_guard': None}}]}])
+            test_ast_dict(self, ":- #sum {1:b} <= 2."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-20",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-20",
+                        "sign": 0,
+                        "atom": {"ast_type": "BooleanConstant", "value": 0},
+                    },
+                    "body": [
+                        {
+                            "ast_type": "Literal",
+                            "location": "<string>:1:4-19",
+                            "sign": 0,
+                            "atom": {
+                                "ast_type": "BodyAggregate",
+                                "location": "<string>:1:4-19",
+                                "left_guard": {
+                                    "ast_type": "Guard",
+                                    "comparison": 3,
+                                    "term": {
+                                        "ast_type": "SymbolicTerm",
+                                        "location": "<string>:1:18-19",
+                                        "symbol": "2",
+                                    },
+                                },
+                                "function": 1,
+                                "elements": [
+                                    {
+                                        "ast_type": "BodyAggregateElement",
+                                        "terms": [
+                                            {
+                                                "ast_type": "SymbolicTerm",
+                                                "location": "<string>:1:10-11",
+                                                "symbol": "1",
+                                            }
+                                        ],
+                                        "condition": [
+                                            {
+                                                "ast_type": "Literal",
+                                                "location": "<string>:1:12-13",
+                                                "sign": 0,
+                                                "atom": {
+                                                    "ast_type": "SymbolicAtom",
+                                                    "symbol": {
+                                                        "ast_type": "Function",
+                                                        "location": "<string>:1:12-13",
+                                                        "name": "b",
+                                                        "arguments": [],
+                                                        "external": 0,
+                                                    },
+                                                },
+                                            }
+                                        ],
+                                    }
+                                ],
+                                "right_guard": None,
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#count {}.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-11',
-              'head': {'ast_type': 'HeadAggregate', 'location': '<string>:1:1-10', 'left_guard': None,
-                       'function': 0, 'elements': [], 'right_guard': None},
-              'body': []}])
+            test_ast_dict(self, "#count {}."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-11",
+                    "head": {
+                        "ast_type": "HeadAggregate",
+                        "location": "<string>:1:1-10",
+                        "left_guard": None,
+                        "function": 0,
+                        "elements": [],
+                        "right_guard": None,
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#min {}.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-9',
-              'head': {'ast_type': 'HeadAggregate', 'location': '<string>:1:1-8', 'left_guard': None,
-                       'function': 3, 'elements': [], 'right_guard': None},
-              'body': []}])
+            test_ast_dict(self, "#min {}."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-9",
+                    "head": {
+                        "ast_type": "HeadAggregate",
+                        "location": "<string>:1:1-8",
+                        "left_guard": None,
+                        "function": 3,
+                        "elements": [],
+                        "right_guard": None,
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#max {}.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-9',
-              'head': {'ast_type': 'HeadAggregate', 'location': '<string>:1:1-8', 'left_guard': None,
-                       'function': 4, 'elements': [], 'right_guard': None},
-              'body': []}])
+            test_ast_dict(self, "#max {}."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-9",
+                    "head": {
+                        "ast_type": "HeadAggregate",
+                        "location": "<string>:1:1-8",
+                        "left_guard": None,
+                        "function": 4,
+                        "elements": [],
+                        "right_guard": None,
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#sum+ {}.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-10',
-              'head': {'ast_type': 'HeadAggregate', 'location': '<string>:1:1-9', 'left_guard': None,
-                       'function': 2, 'elements': [], 'right_guard': None},
-              'body': []}])
+            test_ast_dict(self, "#sum+ {}."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-10",
+                    "head": {
+                        "ast_type": "HeadAggregate",
+                        "location": "<string>:1:1-9",
+                        "left_guard": None,
+                        "function": 2,
+                        "elements": [],
+                        "right_guard": None,
+                    },
+                    "body": [],
+                }
+            ],
+        )
 
     def test_encode_theory(self):
-        '''
+        """
         Tests for converting between python and ast representation of theory
         releated constructs.
-        '''
+        """
         self.assertEqual(
-            test_ast_dict(self, '#theory t { }.'),
-            [{'ast_type': 'TheoryDefinition', 'location': '<string>:1:1-15', 'name': 't', 'terms': [], 'atoms': []}])
+            test_ast_dict(self, "#theory t { }."),
+            [
+                {
+                    "ast_type": "TheoryDefinition",
+                    "location": "<string>:1:1-15",
+                    "name": "t",
+                    "terms": [],
+                    "atoms": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#theory t { t { + : 1, unary } }.'),
-            [{'ast_type': 'TheoryDefinition', 'location': '<string>:1:1-34', 'name': 't',
-              'terms': [{'ast_type': 'TheoryTermDefinition', 'location': '<string>:1:13-31', 'name': 't',
-                         'operators': [{'ast_type': 'TheoryOperatorDefinition', 'location': '<string>:1:17-29',
-                                        'name': '+', 'priority': 1, 'operator_type': 0}]}],
-              'atoms': []}])
+            test_ast_dict(self, "#theory t { t { + : 1, unary } }."),
+            [
+                {
+                    "ast_type": "TheoryDefinition",
+                    "location": "<string>:1:1-34",
+                    "name": "t",
+                    "terms": [
+                        {
+                            "ast_type": "TheoryTermDefinition",
+                            "location": "<string>:1:13-31",
+                            "name": "t",
+                            "operators": [
+                                {
+                                    "ast_type": "TheoryOperatorDefinition",
+                                    "location": "<string>:1:17-29",
+                                    "name": "+",
+                                    "priority": 1,
+                                    "operator_type": 0,
+                                }
+                            ],
+                        }
+                    ],
+                    "atoms": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#theory t { t { + : 1, binary, left } }.'),
-            [{'ast_type': 'TheoryDefinition', 'location': '<string>:1:1-41', 'name': 't',
-              'terms': [{'ast_type': 'TheoryTermDefinition', 'location': '<string>:1:13-38', 'name': 't',
-                         'operators': [{'ast_type': 'TheoryOperatorDefinition', 'location': '<string>:1:17-36',
-                                        'name': '+', 'priority': 1, 'operator_type': 1}]}],
-              'atoms': []}])
+            test_ast_dict(self, "#theory t { t { + : 1, binary, left } }."),
+            [
+                {
+                    "ast_type": "TheoryDefinition",
+                    "location": "<string>:1:1-41",
+                    "name": "t",
+                    "terms": [
+                        {
+                            "ast_type": "TheoryTermDefinition",
+                            "location": "<string>:1:13-38",
+                            "name": "t",
+                            "operators": [
+                                {
+                                    "ast_type": "TheoryOperatorDefinition",
+                                    "location": "<string>:1:17-36",
+                                    "name": "+",
+                                    "priority": 1,
+                                    "operator_type": 1,
+                                }
+                            ],
+                        }
+                    ],
+                    "atoms": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#theory t { t { + : 1, binary, right } }.'),
-            [{'ast_type': 'TheoryDefinition', 'location': '<string>:1:1-42', 'name': 't',
-              'terms': [{'ast_type': 'TheoryTermDefinition', 'location': '<string>:1:13-39', 'name': 't',
-                         'operators': [{'ast_type': 'TheoryOperatorDefinition', 'location': '<string>:1:17-37',
-                                        'name': '+', 'priority': 1, 'operator_type': 2}]}],
-              'atoms': []}])
+            test_ast_dict(self, "#theory t { t { + : 1, binary, right } }."),
+            [
+                {
+                    "ast_type": "TheoryDefinition",
+                    "location": "<string>:1:1-42",
+                    "name": "t",
+                    "terms": [
+                        {
+                            "ast_type": "TheoryTermDefinition",
+                            "location": "<string>:1:13-39",
+                            "name": "t",
+                            "operators": [
+                                {
+                                    "ast_type": "TheoryOperatorDefinition",
+                                    "location": "<string>:1:17-37",
+                                    "name": "+",
+                                    "priority": 1,
+                                    "operator_type": 2,
+                                }
+                            ],
+                        }
+                    ],
+                    "atoms": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#theory t { &p/0 : t, any }.'),
-            [{'ast_type': 'TheoryDefinition', 'location': '<string>:1:1-29', 'name': 't', 'terms': [],
-              'atoms': [{'ast_type': 'TheoryAtomDefinition', 'location': '<string>:1:13-26', 'atom_type': 2,
-                         'name': 'p', 'arity': 0, 'term': 't', 'guard': None}]}])
+            test_ast_dict(self, "#theory t { &p/0 : t, any }."),
+            [
+                {
+                    "ast_type": "TheoryDefinition",
+                    "location": "<string>:1:1-29",
+                    "name": "t",
+                    "terms": [],
+                    "atoms": [
+                        {
+                            "ast_type": "TheoryAtomDefinition",
+                            "location": "<string>:1:13-26",
+                            "atom_type": 2,
+                            "name": "p",
+                            "arity": 0,
+                            "term": "t",
+                            "guard": None,
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#theory t { &p/0 : t, head }.'),
-            [{'ast_type': 'TheoryDefinition', 'location': '<string>:1:1-30', 'name': 't', 'terms': [],
-              'atoms': [{'ast_type': 'TheoryAtomDefinition', 'location': '<string>:1:13-27', 'atom_type': 0,
-                         'name': 'p', 'arity': 0, 'term': 't', 'guard': None}]}])
+            test_ast_dict(self, "#theory t { &p/0 : t, head }."),
+            [
+                {
+                    "ast_type": "TheoryDefinition",
+                    "location": "<string>:1:1-30",
+                    "name": "t",
+                    "terms": [],
+                    "atoms": [
+                        {
+                            "ast_type": "TheoryAtomDefinition",
+                            "location": "<string>:1:13-27",
+                            "atom_type": 0,
+                            "name": "p",
+                            "arity": 0,
+                            "term": "t",
+                            "guard": None,
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#theory t { &p/1 : t, body }.'),
-            [{'ast_type': 'TheoryDefinition', 'location': '<string>:1:1-30', 'name': 't', 'terms': [],
-              'atoms': [{'ast_type': 'TheoryAtomDefinition', 'location': '<string>:1:13-27', 'atom_type': 1,
-                         'name': 'p', 'arity': 1, 'term': 't', 'guard': None}]}])
+            test_ast_dict(self, "#theory t { &p/1 : t, body }."),
+            [
+                {
+                    "ast_type": "TheoryDefinition",
+                    "location": "<string>:1:1-30",
+                    "name": "t",
+                    "terms": [],
+                    "atoms": [
+                        {
+                            "ast_type": "TheoryAtomDefinition",
+                            "location": "<string>:1:13-27",
+                            "atom_type": 1,
+                            "name": "p",
+                            "arity": 1,
+                            "term": "t",
+                            "guard": None,
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#theory t { &p/2 : t, { < }, t, directive }.'),
-            [{'ast_type': 'TheoryDefinition', 'location': '<string>:1:1-45', 'name': 't', 'terms': [],
-              'atoms': [{'ast_type': 'TheoryAtomDefinition', 'location': '<string>:1:13-42', 'atom_type': 3,
-                         'name': 'p', 'arity': 2, 'term': 't',
-                         'guard': {'ast_type': 'TheoryGuardDefinition', 'operators': ['<'], 'term': 't'}}]}])
+            test_ast_dict(self, "#theory t { &p/2 : t, { < }, t, directive }."),
+            [
+                {
+                    "ast_type": "TheoryDefinition",
+                    "location": "<string>:1:1-45",
+                    "name": "t",
+                    "terms": [],
+                    "atoms": [
+                        {
+                            "ast_type": "TheoryAtomDefinition",
+                            "location": "<string>:1:13-42",
+                            "atom_type": 3,
+                            "name": "p",
+                            "arity": 2,
+                            "term": "t",
+                            "guard": {
+                                "ast_type": "TheoryGuardDefinition",
+                                "operators": ["<"],
+                                "term": "t",
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '&p { }.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'TheoryAtom', 'location': '<string>:1:2-3',
-                       'term': {'ast_type': 'Function', 'location': '<string>:1:2-3', 'name': 'p',
-                                'arguments': [], 'external': 0},
-                       'elements': [], 'guard': None}, 'body': []}])
+            test_ast_dict(self, "&p { }."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "TheoryAtom",
+                        "location": "<string>:1:2-3",
+                        "term": {
+                            "ast_type": "Function",
+                            "location": "<string>:1:2-3",
+                            "name": "p",
+                            "arguments": [],
+                            "external": 0,
+                        },
+                        "elements": [],
+                        "guard": None,
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, ':- &p { }.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-11',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-11', 'sign': 0,
-                       'atom': {'ast_type': 'BooleanConstant', 'value': 0}},
-              'body': [{'ast_type': 'Literal', 'location': '<string>:1:4-10', 'sign': 0,
-                        'atom': {'ast_type': 'TheoryAtom', 'location': '<string>:1:5-6',
-                                 'term': {'ast_type': 'Function', 'location': '<string>:1:5-6', 'name': 'p',
-                                          'arguments': [], 'external': 0},
-                                 'elements': [], 'guard': None}}]}])
+            test_ast_dict(self, ":- &p { }."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-11",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-11",
+                        "sign": 0,
+                        "atom": {"ast_type": "BooleanConstant", "value": 0},
+                    },
+                    "body": [
+                        {
+                            "ast_type": "Literal",
+                            "location": "<string>:1:4-10",
+                            "sign": 0,
+                            "atom": {
+                                "ast_type": "TheoryAtom",
+                                "location": "<string>:1:5-6",
+                                "term": {
+                                    "ast_type": "Function",
+                                    "location": "<string>:1:5-6",
+                                    "name": "p",
+                                    "arguments": [],
+                                    "external": 0,
+                                },
+                                "elements": [],
+                                "guard": None,
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '&p { } > 2.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-12',
-              'head': {'ast_type': 'TheoryAtom', 'location': '<string>:1:2-3',
-                       'term': {'ast_type': 'Function', 'location': '<string>:1:2-3', 'name': 'p', 'arguments': [],
-                                'external': 0},
-                       'elements': [], 'guard': {'ast_type': 'TheoryGuard', 'operator_name': '>',
-                                                 'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:10-11',
-                                                          'symbol': '2'}}},
-              'body': []}])
+            test_ast_dict(self, "&p { } > 2."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-12",
+                    "head": {
+                        "ast_type": "TheoryAtom",
+                        "location": "<string>:1:2-3",
+                        "term": {
+                            "ast_type": "Function",
+                            "location": "<string>:1:2-3",
+                            "name": "p",
+                            "arguments": [],
+                            "external": 0,
+                        },
+                        "elements": [],
+                        "guard": {
+                            "ast_type": "TheoryGuard",
+                            "operator_name": ">",
+                            "term": {
+                                "ast_type": "SymbolicTerm",
+                                "location": "<string>:1:10-11",
+                                "symbol": "2",
+                            },
+                        },
+                    },
+                    "body": [],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '&p { a,b: q }.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-15',
-              'head': {'ast_type': 'TheoryAtom', 'location': '<string>:1:2-3',
-                       'term': {'ast_type': 'Function', 'location': '<string>:1:2-3', 'name': 'p', 'arguments': [],
-                                'external': 0},
-                       'elements': [{'ast_type': 'TheoryAtomElement',
-                                     'terms': [{'ast_type': 'SymbolicTerm', 'location': '<string>:1:6-7',
-                                                'symbol': 'a'},
-                                               {'ast_type': 'SymbolicTerm', 'location': '<string>:1:8-9',
-                                                'symbol': 'b'}],
-                                     'condition': [{'ast_type': 'Literal', 'location': '<string>:1:11-12', 'sign': 0,
-                                                    'atom': {'ast_type': 'SymbolicAtom',
-                                                             'symbol': {'ast_type': 'Function',
-                                                                        'location': '<string>:1:11-12', 'name': 'q',
-                                                                        'arguments': [], 'external': 0}}}]}],
-                       'guard': None},
-              'body': []}])
+            test_ast_dict(self, "&p { a,b: q }."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-15",
+                    "head": {
+                        "ast_type": "TheoryAtom",
+                        "location": "<string>:1:2-3",
+                        "term": {
+                            "ast_type": "Function",
+                            "location": "<string>:1:2-3",
+                            "name": "p",
+                            "arguments": [],
+                            "external": 0,
+                        },
+                        "elements": [
+                            {
+                                "ast_type": "TheoryAtomElement",
+                                "terms": [
+                                    {
+                                        "ast_type": "SymbolicTerm",
+                                        "location": "<string>:1:6-7",
+                                        "symbol": "a",
+                                    },
+                                    {
+                                        "ast_type": "SymbolicTerm",
+                                        "location": "<string>:1:8-9",
+                                        "symbol": "b",
+                                    },
+                                ],
+                                "condition": [
+                                    {
+                                        "ast_type": "Literal",
+                                        "location": "<string>:1:11-12",
+                                        "sign": 0,
+                                        "atom": {
+                                            "ast_type": "SymbolicAtom",
+                                            "symbol": {
+                                                "ast_type": "Function",
+                                                "location": "<string>:1:11-12",
+                                                "name": "q",
+                                                "arguments": [],
+                                                "external": 0,
+                                            },
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                        "guard": None,
+                    },
+                    "body": [],
+                }
+            ],
+        )
 
     def test_encode_statement(self):
-        '''
+        """
         Tests for converting between python and ast representation of statements.
-        '''
+        """
         # Note: tests are simply skipped for older clingo versions
         if clingo.version() < (5, 6, 0):
             return  # nocoverage
         self.assertEqual(
-            test_ast_dict(self, 'a :- b.'),
-            [{'ast_type': 'Rule', 'location': '<string>:1:1-8',
-              'head': {'ast_type': 'Literal', 'location': '<string>:1:1-2', 'sign': 0,
-                       'atom': {'ast_type': 'SymbolicAtom',
-                                'symbol': {'ast_type': 'Function', 'location': '<string>:1:1-2',
-                                           'name': 'a', 'arguments': [], 'external': 0}}},
-              'body': [{'ast_type': 'Literal', 'location': '<string>:1:6-7', 'sign': 0,
-                        'atom': {'ast_type': 'SymbolicAtom',
-                                 'symbol': {'ast_type': 'Function', 'location': '<string>:1:6-7',
-                                            'name': 'b', 'arguments': [], 'external': 0}}}]}])
+            test_ast_dict(self, "a :- b."),
+            [
+                {
+                    "ast_type": "Rule",
+                    "location": "<string>:1:1-8",
+                    "head": {
+                        "ast_type": "Literal",
+                        "location": "<string>:1:1-2",
+                        "sign": 0,
+                        "atom": {
+                            "ast_type": "SymbolicAtom",
+                            "symbol": {
+                                "ast_type": "Function",
+                                "location": "<string>:1:1-2",
+                                "name": "a",
+                                "arguments": [],
+                                "external": 0,
+                            },
+                        },
+                    },
+                    "body": [
+                        {
+                            "ast_type": "Literal",
+                            "location": "<string>:1:6-7",
+                            "sign": 0,
+                            "atom": {
+                                "ast_type": "SymbolicAtom",
+                                "symbol": {
+                                    "ast_type": "Function",
+                                    "location": "<string>:1:6-7",
+                                    "name": "b",
+                                    "arguments": [],
+                                    "external": 0,
+                                },
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#defined x/0.'),
-            [{'ast_type': 'Defined', 'location': '<string>:1:1-14', 'name': 'x', 'arity': 0, 'positive': True}])
+            test_ast_dict(self, "#defined x/0."),
+            [
+                {
+                    "ast_type": "Defined",
+                    "location": "<string>:1:1-14",
+                    "name": "x",
+                    "arity": 0,
+                    "positive": True,
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#show a : b.'),
-            [{'ast_type': 'ShowTerm', 'location': '<string>:1:1-13',
-              'term': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:7-8', 'symbol': 'a'},
-              'body': [{'ast_type': 'Literal', 'location': '<string>:1:11-12', 'sign': 0,
-                        'atom': {'ast_type': 'SymbolicAtom',
-                                 'symbol': {'ast_type': 'Function', 'location': '<string>:1:11-12', 'name': 'b',
-                                            'arguments': [], 'external': 0}}}]}])
+            test_ast_dict(self, "#show a : b."),
+            [
+                {
+                    "ast_type": "ShowTerm",
+                    "location": "<string>:1:1-13",
+                    "term": {
+                        "ast_type": "SymbolicTerm",
+                        "location": "<string>:1:7-8",
+                        "symbol": "a",
+                    },
+                    "body": [
+                        {
+                            "ast_type": "Literal",
+                            "location": "<string>:1:11-12",
+                            "sign": 0,
+                            "atom": {
+                                "ast_type": "SymbolicAtom",
+                                "symbol": {
+                                    "ast_type": "Function",
+                                    "location": "<string>:1:11-12",
+                                    "name": "b",
+                                    "arguments": [],
+                                    "external": 0,
+                                },
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#show a/0.'),
-            [{'ast_type': 'ShowSignature', 'location': '<string>:1:1-11', 'name': 'a', 'arity': 0, 'positive': True}])
+            test_ast_dict(self, "#show a/0."),
+            [
+                {
+                    "ast_type": "ShowSignature",
+                    "location": "<string>:1:1-11",
+                    "name": "a",
+                    "arity": 0,
+                    "positive": True,
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#minimize { 1@2,a : b }.'),
-            [{'ast_type': 'Minimize', 'location': '<string>:1:13-22',
-              'weight': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:13-14', 'symbol': '1'},
-              'priority': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:15-16', 'symbol': '2'},
-              'terms': [{'ast_type': 'SymbolicTerm', 'location': '<string>:1:17-18', 'symbol': 'a'}],
-              'body': [{'ast_type': 'Literal', 'location': '<string>:1:21-22', 'sign': 0,
-                        'atom': {'ast_type': 'SymbolicAtom',
-                                 'symbol': {'ast_type': 'Function', 'location': '<string>:1:21-22', 'name': 'b',
-                                            'arguments': [], 'external': 0}}}]}])
+            test_ast_dict(self, "#minimize { 1@2,a : b }."),
+            [
+                {
+                    "ast_type": "Minimize",
+                    "location": "<string>:1:13-22",
+                    "weight": {
+                        "ast_type": "SymbolicTerm",
+                        "location": "<string>:1:13-14",
+                        "symbol": "1",
+                    },
+                    "priority": {
+                        "ast_type": "SymbolicTerm",
+                        "location": "<string>:1:15-16",
+                        "symbol": "2",
+                    },
+                    "terms": [
+                        {
+                            "ast_type": "SymbolicTerm",
+                            "location": "<string>:1:17-18",
+                            "symbol": "a",
+                        }
+                    ],
+                    "body": [
+                        {
+                            "ast_type": "Literal",
+                            "location": "<string>:1:21-22",
+                            "sign": 0,
+                            "atom": {
+                                "ast_type": "SymbolicAtom",
+                                "symbol": {
+                                    "ast_type": "Function",
+                                    "location": "<string>:1:21-22",
+                                    "name": "b",
+                                    "arguments": [],
+                                    "external": 0,
+                                },
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#script (python) blub! #end.'),
-            [{'ast_type': 'Script', 'location': '<string>:1:1-29', 'name': 'python',
-              'code': 'blub!'}])
+            test_ast_dict(self, "#script (python) blub! #end."),
+            [
+                {
+                    "ast_type": "Script",
+                    "location": "<string>:1:1-29",
+                    "name": "python",
+                    "code": "blub!",
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#script (lua) blub! #end.'),
-            [{'ast_type': 'Script', 'location': '<string>:1:1-26', 'code': 'blub!', 'name': 'lua'}])
+            test_ast_dict(self, "#script (lua) blub! #end."),
+            [
+                {
+                    "ast_type": "Script",
+                    "location": "<string>:1:1-26",
+                    "code": "blub!",
+                    "name": "lua",
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#program x(y).'),
-            [{'ast_type': 'Program', 'location': '<string>:1:1-15', 'name': 'x',
-              'parameters': [{'ast_type': 'Id', 'location': '<string>:1:12-13', 'name': 'y'}]}])
+            test_ast_dict(self, "#program x(y)."),
+            [
+                {
+                    "ast_type": "Program",
+                    "location": "<string>:1:1-15",
+                    "name": "x",
+                    "parameters": [
+                        {"ast_type": "Id", "location": "<string>:1:12-13", "name": "y"}
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#project a/0.'),
-            [{'ast_type': 'ProjectSignature', 'location': '<string>:1:1-14', 'name': 'a', 'arity': 0,
-              'positive': True}])
+            test_ast_dict(self, "#project a/0."),
+            [
+                {
+                    "ast_type": "ProjectSignature",
+                    "location": "<string>:1:1-14",
+                    "name": "a",
+                    "arity": 0,
+                    "positive": True,
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#project a : b.'),
-            [{'ast_type': 'ProjectAtom', 'location': '<string>:1:1-16',
-              'atom': {'ast_type': 'SymbolicAtom',
-                       'symbol': {'ast_type': 'Function', 'location': '<string>:1:10-11', 'name': 'a',
-                                  'arguments': [], 'external': 0}},
-              'body': [{'ast_type': 'Literal', 'location': '<string>:1:14-15', 'sign': 0,
-                        'atom': {'ast_type': 'SymbolicAtom',
-                                 'symbol': {'ast_type': 'Function', 'location': '<string>:1:14-15', 'name': 'b',
-                                            'arguments': [], 'external': 0}}}]}])
+            test_ast_dict(self, "#project a : b."),
+            [
+                {
+                    "ast_type": "ProjectAtom",
+                    "location": "<string>:1:1-16",
+                    "atom": {
+                        "ast_type": "SymbolicAtom",
+                        "symbol": {
+                            "ast_type": "Function",
+                            "location": "<string>:1:10-11",
+                            "name": "a",
+                            "arguments": [],
+                            "external": 0,
+                        },
+                    },
+                    "body": [
+                        {
+                            "ast_type": "Literal",
+                            "location": "<string>:1:14-15",
+                            "sign": 0,
+                            "atom": {
+                                "ast_type": "SymbolicAtom",
+                                "symbol": {
+                                    "ast_type": "Function",
+                                    "location": "<string>:1:14-15",
+                                    "name": "b",
+                                    "arguments": [],
+                                    "external": 0,
+                                },
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#external x : y. [X]'),
-            [{'ast_type': 'External', 'location': '<string>:1:1-21',
-              'atom': {'ast_type': 'SymbolicAtom',
-                       'symbol': {'ast_type': 'Function', 'location': '<string>:1:11-12', 'name': 'x',
-                                  'arguments': [], 'external': 0}},
-              'body': [{'ast_type': 'Literal', 'location': '<string>:1:15-16', 'sign': 0,
-                        'atom': {'ast_type': 'SymbolicAtom',
-                                 'symbol': {'ast_type': 'Function', 'location': '<string>:1:15-16', 'name': 'y',
-                                            'arguments': [], 'external': 0}}}],
-              'external_type': {'ast_type': 'Variable', 'location': '<string>:1:19-20', 'name': 'X'}}])
+            test_ast_dict(self, "#external x : y. [X]"),
+            [
+                {
+                    "ast_type": "External",
+                    "location": "<string>:1:1-21",
+                    "atom": {
+                        "ast_type": "SymbolicAtom",
+                        "symbol": {
+                            "ast_type": "Function",
+                            "location": "<string>:1:11-12",
+                            "name": "x",
+                            "arguments": [],
+                            "external": 0,
+                        },
+                    },
+                    "body": [
+                        {
+                            "ast_type": "Literal",
+                            "location": "<string>:1:15-16",
+                            "sign": 0,
+                            "atom": {
+                                "ast_type": "SymbolicAtom",
+                                "symbol": {
+                                    "ast_type": "Function",
+                                    "location": "<string>:1:15-16",
+                                    "name": "y",
+                                    "arguments": [],
+                                    "external": 0,
+                                },
+                            },
+                        }
+                    ],
+                    "external_type": {
+                        "ast_type": "Variable",
+                        "location": "<string>:1:19-20",
+                        "name": "X",
+                    },
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#edge (u,v) : b.'),
-            [{'ast_type': 'Edge', 'location': '<string>:1:1-17',
-              'node_u': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:8-9', 'symbol': 'u'},
-              'node_v': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:10-11', 'symbol': 'v'},
-              'body': [{'ast_type': 'Literal', 'location': '<string>:1:15-16', 'sign': 0,
-                        'atom': {'ast_type': 'SymbolicAtom',
-                                 'symbol': {'ast_type': 'Function', 'location': '<string>:1:15-16', 'name': 'b',
-                                            'arguments': [], 'external': 0}}}]}])
+            test_ast_dict(self, "#edge (u,v) : b."),
+            [
+                {
+                    "ast_type": "Edge",
+                    "location": "<string>:1:1-17",
+                    "node_u": {
+                        "ast_type": "SymbolicTerm",
+                        "location": "<string>:1:8-9",
+                        "symbol": "u",
+                    },
+                    "node_v": {
+                        "ast_type": "SymbolicTerm",
+                        "location": "<string>:1:10-11",
+                        "symbol": "v",
+                    },
+                    "body": [
+                        {
+                            "ast_type": "Literal",
+                            "location": "<string>:1:15-16",
+                            "sign": 0,
+                            "atom": {
+                                "ast_type": "SymbolicAtom",
+                                "symbol": {
+                                    "ast_type": "Function",
+                                    "location": "<string>:1:15-16",
+                                    "name": "b",
+                                    "arguments": [],
+                                    "external": 0,
+                                },
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(
-            test_ast_dict(self, '#heuristic a : b. [p,X]'),
-            [{'ast_type': 'Heuristic', 'location': '<string>:1:1-24',
-              'atom': {'ast_type': 'SymbolicAtom',
-                       'symbol': {'ast_type': 'Function', 'location': '<string>:1:12-13', 'name': 'a',
-                                  'arguments': [], 'external': 0}},
-              'body': [{'ast_type': 'Literal', 'location': '<string>:1:16-17', 'sign': 0,
-                        'atom': {'ast_type': 'SymbolicAtom',
-                                 'symbol': {'ast_type': 'Function', 'location': '<string>:1:16-17', 'name': 'b',
-                                            'arguments': [], 'external': 0}}}],
-              'bias': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:20-21', 'symbol': 'p'},
-              'priority': {'ast_type': 'SymbolicTerm', 'location': '<string>:1:1-24', 'symbol': '0'},
-              'modifier': {'ast_type': 'Variable', 'location': '<string>:1:22-23', 'name': 'X'}}])
+            test_ast_dict(self, "#heuristic a : b. [p,X]"),
+            [
+                {
+                    "ast_type": "Heuristic",
+                    "location": "<string>:1:1-24",
+                    "atom": {
+                        "ast_type": "SymbolicAtom",
+                        "symbol": {
+                            "ast_type": "Function",
+                            "location": "<string>:1:12-13",
+                            "name": "a",
+                            "arguments": [],
+                            "external": 0,
+                        },
+                    },
+                    "body": [
+                        {
+                            "ast_type": "Literal",
+                            "location": "<string>:1:16-17",
+                            "sign": 0,
+                            "atom": {
+                                "ast_type": "SymbolicAtom",
+                                "symbol": {
+                                    "ast_type": "Function",
+                                    "location": "<string>:1:16-17",
+                                    "name": "b",
+                                    "arguments": [],
+                                    "external": 0,
+                                },
+                            },
+                        }
+                    ],
+                    "bias": {
+                        "ast_type": "SymbolicTerm",
+                        "location": "<string>:1:20-21",
+                        "symbol": "p",
+                    },
+                    "priority": {
+                        "ast_type": "SymbolicTerm",
+                        "location": "<string>:1:1-24",
+                        "symbol": "0",
+                    },
+                    "modifier": {
+                        "ast_type": "Variable",
+                        "location": "<string>:1:22-23",
+                        "name": "X",
+                    },
+                }
+            ],
+        )
 
     def test_dict_ast_error(self):
-        '''
+        """
         Test error conditions when converting between ast and dict.
-        '''
-        self.assertRaises(RuntimeError, dict_to_ast, {"ast_type": "Rule", "body": set()})
+        """
+        self.assertRaises(
+            RuntimeError, dict_to_ast, {"ast_type": "Rule", "body": set()}
+        )
 
-    def helper_get_body(self,
-                        stm: str,
-                        body: Sequence[str],
-                        exclude_signs: Container[Sign] = (Sign.Negation, Sign.DoubleNegation),
-                        exclude_theory_atoms: bool = False,
-                        exclude_aggregates: bool = False,
-                        exclude_conditional_literals: bool = False):
-        '''
+    def helper_get_body(
+        self,
+        stm: str,
+        body: Sequence[str],
+        exclude_signs: Container[Sign] = (Sign.Negation, Sign.DoubleNegation),
+        exclude_theory_atoms: bool = False,
+        exclude_aggregates: bool = False,
+        exclude_conditional_literals: bool = False,
+    ):
+        """
         Helper for testing get_body.
-        '''
-        res = get_body(last_stm(stm), exclude_signs, exclude_theory_atoms, exclude_aggregates,
-                       exclude_conditional_literals)
+        """
+        res = get_body(
+            last_stm(stm),
+            exclude_signs,
+            exclude_theory_atoms,
+            exclude_aggregates,
+            exclude_conditional_literals,
+        )
         self.assertListEqual(sorted(body), sorted(str(s) for s in res))
 
     def test_get_positive_body(self):
-        '''
+        """
         Test for get_body.
-        '''
+        """
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), not d(X), not not e(X,Y).',
-            ['b(X)', 'c(Y)'])
+            "a(X) :- b(X), c(Y), not d(X), not not e(X,Y).", ["b(X)", "c(Y)"]
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.',
-            ['b(X)', 'c(Y)', 'Z = #sum { X: d(X) }'])
+            "a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.",
+            ["b(X)", "c(Y)", "Z = #sum { X: d(X) }"],
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.',
-            ['b(X)', 'c(Y)', '&sum { X: d(X) } = Z'])
+            "a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.",
+            ["b(X)", "c(Y)", "&sum { X: d(X) } = Z"],
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = { d(X) }.',
-            ['b(X)', 'c(Y)', 'Z = { d(X) }'])
+            "a(X) :- b(X), c(Y), Z = { d(X) }.", ["b(X)", "c(Y)", "Z = { d(X) }"]
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), d(Z): e(X,Z).',
-            ['b(X)', 'c(Y)', 'd(Z): e(X,Z)'])
+            "a(X) :- b(X), c(Y), d(Z): e(X,Z).", ["b(X)", "c(Y)", "d(Z): e(X,Z)"]
+        )
 
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), not d(X), not not e(X,Y).',
-            ['b(X)', 'c(Y)'],
-            exclude_theory_atoms=True)
-        self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.',
-            ['b(X)', 'c(Y)', 'Z = #sum { X: d(X) }'],
-            exclude_theory_atoms=True)
-        self.helper_get_body(
-            'a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.',
-            ['b(X)', 'c(Y)'],
-            exclude_theory_atoms=True)
-        self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = { d(X) }.',
-            ['b(X)', 'c(Y)', 'Z = { d(X) }'],
-            exclude_theory_atoms=True)
-        self.helper_get_body(
-            'a(X) :- b(X), c(Y), d(Z): e(X,Z).',
-            ['b(X)', 'c(Y)', 'd(Z): e(X,Z)'],
-            exclude_theory_atoms=True)
-
-        self.helper_get_body(
-            'a(X) :- b(X), c(Y), not d(X), not not e(X,Y).',
-            ['b(X)', 'c(Y)'],
-            exclude_aggregates=True)
-        self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.',
-            ['b(X)', 'c(Y)'],
-            exclude_aggregates=True)
-        self.helper_get_body(
-            'a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.',
-            ['b(X)', 'c(Y)', '&sum { X: d(X) } = Z'],
-            exclude_aggregates=True)
-        self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = { d(X) }.',
-            ['b(X)', 'c(Y)'],
-            exclude_aggregates=True)
-        self.helper_get_body(
-            'a(X) :- b(X), c(Y), d(Z): e(X,Z).',
-            ['b(X)', 'c(Y)', 'd(Z): e(X,Z)'],
-            exclude_aggregates=True)
-
-        self.helper_get_body(
-            'a(X) :- b(X), c(Y), not d(X), not not e(X,Y).',
-            ['b(X)', 'c(Y)'],
+            "a(X) :- b(X), c(Y), not d(X), not not e(X,Y).",
+            ["b(X)", "c(Y)"],
             exclude_theory_atoms=True,
-            exclude_aggregates=True)
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.',
-            ['b(X)', 'c(Y)'],
+            "a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.",
+            ["b(X)", "c(Y)", "Z = #sum { X: d(X) }"],
             exclude_theory_atoms=True,
-            exclude_aggregates=True)
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.',
-            ['b(X)', 'c(Y)'],
+            "a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.",
+            ["b(X)", "c(Y)"],
             exclude_theory_atoms=True,
-            exclude_aggregates=True)
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = { d(X) }.',
-            ['b(X)', 'c(Y)'],
+            "a(X) :- b(X), c(Y), Z = { d(X) }.",
+            ["b(X)", "c(Y)", "Z = { d(X) }"],
             exclude_theory_atoms=True,
-            exclude_aggregates=True)
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), d(Z): e(X,Z).',
-            ['b(X)', 'c(Y)', 'd(Z): e(X,Z)'],
+            "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
+            ["b(X)", "c(Y)", "d(Z): e(X,Z)"],
             exclude_theory_atoms=True,
-            exclude_aggregates=True)
+        )
 
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), not d(X), not not e(X,Y).',
-            ['b(X)', 'c(Y)', 'not d(X)'],
-            exclude_signs=(Sign.DoubleNegation,))
+            "a(X) :- b(X), c(Y), not d(X), not not e(X,Y).",
+            ["b(X)", "c(Y)"],
+            exclude_aggregates=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.',
-            ['b(X)', 'c(Y)', 'Z = #sum { X: d(X) }'],
-            exclude_signs=(Sign.DoubleNegation,))
+            "a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.",
+            ["b(X)", "c(Y)"],
+            exclude_aggregates=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.',
-            ['b(X)', 'c(Y)', '&sum { X: d(X) } = Z'],
-            exclude_signs=(Sign.DoubleNegation,))
+            "a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.",
+            ["b(X)", "c(Y)", "&sum { X: d(X) } = Z"],
+            exclude_aggregates=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = { d(X) }.',
-            ['b(X)', 'c(Y)', 'Z = { d(X) }'],
-            exclude_signs=(Sign.DoubleNegation,))
+            "a(X) :- b(X), c(Y), Z = { d(X) }.",
+            ["b(X)", "c(Y)"],
+            exclude_aggregates=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), d(Z): e(X,Z).',
-            ['b(X)', 'c(Y)', 'd(Z): e(X,Z)'],
-            exclude_signs=(Sign.DoubleNegation,))
+            "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
+            ["b(X)", "c(Y)", "d(Z): e(X,Z)"],
+            exclude_aggregates=True,
+        )
 
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), not d(X), not not e(X,Y).',
-            ['b(X)', 'c(Y)', 'not not e(X,Y)'],
-            exclude_signs=(Sign.Negation,))
+            "a(X) :- b(X), c(Y), not d(X), not not e(X,Y).",
+            ["b(X)", "c(Y)"],
+            exclude_theory_atoms=True,
+            exclude_aggregates=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.',
-            ['b(X)', 'c(Y)', 'Z = #sum { X: d(X) }'],
-            exclude_signs=(Sign.Negation,))
+            "a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.",
+            ["b(X)", "c(Y)"],
+            exclude_theory_atoms=True,
+            exclude_aggregates=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.',
-            ['b(X)', 'c(Y)', '&sum { X: d(X) } = Z'],
-            exclude_signs=(Sign.Negation,))
+            "a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.",
+            ["b(X)", "c(Y)"],
+            exclude_theory_atoms=True,
+            exclude_aggregates=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = { d(X) }.',
-            ['b(X)', 'c(Y)', 'Z = { d(X) }'],
-            exclude_signs=(Sign.Negation,))
+            "a(X) :- b(X), c(Y), Z = { d(X) }.",
+            ["b(X)", "c(Y)"],
+            exclude_theory_atoms=True,
+            exclude_aggregates=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), d(Z): e(X,Z).',
-            ['b(X)', 'c(Y)', 'd(Z): e(X,Z)'],
-            exclude_signs=(Sign.Negation,))
+            "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
+            ["b(X)", "c(Y)", "d(Z): e(X,Z)"],
+            exclude_theory_atoms=True,
+            exclude_aggregates=True,
+        )
 
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), not d(X), not not e(X,Y).',
-            ['not d(X)', 'not not e(X,Y)'],
-            exclude_signs=(Sign.NoSign,))
+            "a(X) :- b(X), c(Y), not d(X), not not e(X,Y).",
+            ["b(X)", "c(Y)", "not d(X)"],
+            exclude_signs=(Sign.DoubleNegation,),
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.',
+            "a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.",
+            ["b(X)", "c(Y)", "Z = #sum { X: d(X) }"],
+            exclude_signs=(Sign.DoubleNegation,),
+        )
+        self.helper_get_body(
+            "a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.",
+            ["b(X)", "c(Y)", "&sum { X: d(X) } = Z"],
+            exclude_signs=(Sign.DoubleNegation,),
+        )
+        self.helper_get_body(
+            "a(X) :- b(X), c(Y), Z = { d(X) }.",
+            ["b(X)", "c(Y)", "Z = { d(X) }"],
+            exclude_signs=(Sign.DoubleNegation,),
+        )
+        self.helper_get_body(
+            "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
+            ["b(X)", "c(Y)", "d(Z): e(X,Z)"],
+            exclude_signs=(Sign.DoubleNegation,),
+        )
+
+        self.helper_get_body(
+            "a(X) :- b(X), c(Y), not d(X), not not e(X,Y).",
+            ["b(X)", "c(Y)", "not not e(X,Y)"],
+            exclude_signs=(Sign.Negation,),
+        )
+        self.helper_get_body(
+            "a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.",
+            ["b(X)", "c(Y)", "Z = #sum { X: d(X) }"],
+            exclude_signs=(Sign.Negation,),
+        )
+        self.helper_get_body(
+            "a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.",
+            ["b(X)", "c(Y)", "&sum { X: d(X) } = Z"],
+            exclude_signs=(Sign.Negation,),
+        )
+        self.helper_get_body(
+            "a(X) :- b(X), c(Y), Z = { d(X) }.",
+            ["b(X)", "c(Y)", "Z = { d(X) }"],
+            exclude_signs=(Sign.Negation,),
+        )
+        self.helper_get_body(
+            "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
+            ["b(X)", "c(Y)", "d(Z): e(X,Z)"],
+            exclude_signs=(Sign.Negation,),
+        )
+
+        self.helper_get_body(
+            "a(X) :- b(X), c(Y), not d(X), not not e(X,Y).",
+            ["not d(X)", "not not e(X,Y)"],
+            exclude_signs=(Sign.NoSign,),
+        )
+        self.helper_get_body(
+            "a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.",
             [],
-            exclude_signs=(Sign.NoSign,))
+            exclude_signs=(Sign.NoSign,),
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.',
+            "a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.",
             [],
-            exclude_signs=(Sign.NoSign,))
+            exclude_signs=(Sign.NoSign,),
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = { d(X) }.',
-            [],
-            exclude_signs=(Sign.NoSign,))
+            "a(X) :- b(X), c(Y), Z = { d(X) }.", [], exclude_signs=(Sign.NoSign,)
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), d(Z): e(X,Z).',
-            ['d(Z): e(X,Z)'],
-            exclude_signs=(Sign.NoSign,))
+            "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
+            ["d(Z): e(X,Z)"],
+            exclude_signs=(Sign.NoSign,),
+        )
 
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), not d(X), not not e(X,Y).',
-            ['b(X)', 'c(Y)'],
-            exclude_conditional_literals=True)
+            "a(X) :- b(X), c(Y), not d(X), not not e(X,Y).",
+            ["b(X)", "c(Y)"],
+            exclude_conditional_literals=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.',
-            ['b(X)', 'c(Y)', 'Z = #sum { X: d(X) }'],
-            exclude_conditional_literals=True)
+            "a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.",
+            ["b(X)", "c(Y)", "Z = #sum { X: d(X) }"],
+            exclude_conditional_literals=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.',
-            ['b(X)', 'c(Y)', '&sum { X: d(X) } = Z'],
-            exclude_conditional_literals=True)
+            "a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.",
+            ["b(X)", "c(Y)", "&sum { X: d(X) } = Z"],
+            exclude_conditional_literals=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), Z = { d(X) }.',
-            ['b(X)', 'c(Y)', 'Z = { d(X) }'],
-            exclude_conditional_literals=True)
+            "a(X) :- b(X), c(Y), Z = { d(X) }.",
+            ["b(X)", "c(Y)", "Z = { d(X) }"],
+            exclude_conditional_literals=True,
+        )
         self.helper_get_body(
-            'a(X) :- b(X), c(Y), d(Z): e(X,Z).',
-            ['b(X)', 'c(Y)'],
-            exclude_conditional_literals=True)
+            "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
+            ["b(X)", "c(Y)"],
+            exclude_conditional_literals=True,
+        )

--- a/clingox/tests/test_backend.py
+++ b/clingox/tests/test_backend.py
@@ -1,6 +1,6 @@
-'''
+"""
 Test cases for the symbolic symbolic_backend.
-'''
+"""
 from unittest import TestCase
 
 from clingo import Control, Function, HeuristicType, TruthValue
@@ -9,9 +9,9 @@ from clingox.program import Program, ProgramObserver
 
 
 class TestSymbolicBackend(TestCase):
-    '''
+    """
     Tests for the ymbolic symbolic_backend.
-    '''
+    """
 
     def setUp(self):
         self.prg = Program()
@@ -20,9 +20,9 @@ class TestSymbolicBackend(TestCase):
         self.ctl.register_observer(self.obs)
 
     def test_add_acyc_edge(self):
-        '''
+        """
         Test edge statement.
-        '''
+        """
         a = Function("a", [Function("c1")])
         b = Function("b", [Function("c2")])
         c = Function("c", [Function("c3")])
@@ -31,9 +31,9 @@ class TestSymbolicBackend(TestCase):
         self.assertEqual(str(self.prg), "#edge (1,3): a(c1), not b(c2), not c(c3).")
 
     def test_add_assume(self):
-        '''
+        """
         Test assumptions.
-        '''
+        """
         a = Function("a", [Function("c1")])
         b = Function("b", [Function("c2")])
         c = Function("c", [Function("c3")])
@@ -42,59 +42,65 @@ class TestSymbolicBackend(TestCase):
         self.assertEqual(str(self.prg), "% assumptions: a(c1), b(c2), c(c3)")
 
     def test_add_external(self):
-        '''
+        """
         Test external statement.
-        '''
+        """
         a = Function("a", [Function("c1")])
         with SymbolicBackend(self.ctl.backend()) as symbolic_backend:
             symbolic_backend.add_external(a, TruthValue.True_)
         self.assertEqual(str(self.prg), "#external a(c1). [True]")
 
     def test_add_heuristic(self):
-        '''
+        """
         Test heuristic statement.
-        '''
+        """
         a = Function("a", [Function("c1")])
         b = Function("b", [Function("c2")])
         c = Function("c", [Function("c3")])
         with SymbolicBackend(self.ctl.backend()) as symbolic_backend:
             symbolic_backend.add_heuristic(a, HeuristicType.Level, 2, 3, [b], [c])
-        self.assertEqual(str(self.prg), "#heuristic a(c1): b(c2), not c(c3). [2@3, Level]")
+        self.assertEqual(
+            str(self.prg), "#heuristic a(c1): b(c2), not c(c3). [2@3, Level]"
+        )
 
     def test_add_minimize(self):
-        '''
+        """
         Test minimize statement.
-        '''
+        """
         a = Function("a", [Function("c1")])
         b = Function("b", [Function("c2")])
         c = Function("c", [Function("c3")])
         with SymbolicBackend(self.ctl.backend()) as symbolic_backend:
             symbolic_backend.add_minimize(1, [(a, 3), (b, 5)], [(c, 7)])
-        self.assertEqual(str(self.prg), "#minimize{3@1,0: a(c1); 5@1,1: b(c2); 7@1,2: not c(c3)}.")
+        self.assertEqual(
+            str(self.prg), "#minimize{3@1,0: a(c1); 5@1,1: b(c2); 7@1,2: not c(c3)}."
+        )
 
     def test_add_project(self):
-        '''
+        """
         Test project statements.
-        '''
+        """
         a = Function("a", [Function("c1")])
         b = Function("b", [Function("c2")])
         c = Function("c", [Function("c3")])
         with SymbolicBackend(self.ctl.backend()) as symbolic_backend:
             symbolic_backend.add_project([a, b, c])
-        self.assertEqual(str(self.prg), "#project a(c1).\n#project b(c2).\n#project c(c3).")
+        self.assertEqual(
+            str(self.prg), "#project a(c1).\n#project b(c2).\n#project c(c3)."
+        )
 
     def test_add_empty_project(self):
-        '''
+        """
         Test project statements.
-        '''
+        """
         with SymbolicBackend(self.ctl.backend()) as symbolic_backend:
             symbolic_backend.add_project([])
         self.assertEqual(str(self.prg), "#project x: #false.")
 
     def test_add_rule(self):
-        '''
+        """
         Test simple rules.
-        '''
+        """
         a = Function("a", [Function("c1")])
         b = Function("b", [Function("c2")])
         c = Function("c", [Function("c3")])
@@ -103,9 +109,9 @@ class TestSymbolicBackend(TestCase):
         self.assertEqual(str(self.prg), "a(c1) :- b(c2), not c(c3).")
 
     def test_add_choice_rule(self):
-        '''
+        """
         Test choice rules.
-        '''
+        """
         a = Function("a", [Function("c1")])
         b = Function("b", [Function("c2")])
         c = Function("c", [Function("c3")])
@@ -114,9 +120,9 @@ class TestSymbolicBackend(TestCase):
         self.assertEqual(str(self.prg), "{a(c1)} :- b(c2), not c(c3).")
 
     def test_add_weight_rule(self):
-        '''
+        """
         Test weight rules.
-        '''
+        """
         a = Function("a", [Function("c1")])
         b = Function("b", [Function("c2")])
         c = Function("c", [Function("c3")])
@@ -125,9 +131,9 @@ class TestSymbolicBackend(TestCase):
         self.assertEqual(str(self.prg), "a(c1) :- 3{5,0: b(c2), 7,1: not c(c3)}.")
 
     def test_add_weight_choice_rule(self):
-        '''
+        """
         Test weight rules that are also choice rules.
-        '''
+        """
         a = Function("a", [Function("c1")])
         b = Function("b", [Function("c2")])
         c = Function("c", [Function("c3")])

--- a/clingox/tests/test_program.py
+++ b/clingox/tests/test_program.py
@@ -1,25 +1,37 @@
-'''
+"""
 Test cases for the ground program and observer.
-'''
+"""
 from unittest import TestCase
 
 from typing import cast
 
 from clingo import Control, Function, HeuristicType, TruthValue
 
-from clingox.program import (Edge, External, Fact, Heuristic, Minimize, Program, ProgramObserver, Project,
-                             Remapping, Rule, Show, WeightRule,
-                             remap)
+from clingox.program import (
+    Edge,
+    External,
+    Fact,
+    Heuristic,
+    Minimize,
+    Program,
+    ProgramObserver,
+    Project,
+    Remapping,
+    Rule,
+    Show,
+    WeightRule,
+    remap,
+)
 
 
 def _remap(prg: Program, mapping=None):
-    '''
+    """
     Add the given program to a backend passing it through an observer and then
     return the observer program.
 
     The resulting program is initialized with the symbols from the orginial
     program.
-    '''
+    """
 
     ctl, chk = Control(), Program()
     # note that output atoms are not passed to the backend
@@ -40,16 +52,17 @@ def _remap(prg: Program, mapping=None):
 
 
 def _plus10(atom):
-    '''
+    """
     Simple mapping adding +10 to every atom.
-    '''
+    """
     return atom + 10
 
 
 class TestProgram(TestCase):
-    '''
+    """
     Tests for the program observer.
-    '''
+    """
+
     prg: Program
     obs: ProgramObserver
 
@@ -63,9 +76,9 @@ class TestProgram(TestCase):
         self.obs = ProgramObserver(self.prg)
 
     def _add_atoms(self, *atoms: str):
-        '''
+        """
         Generate an output table for the given atom names.
-        '''
+        """
         lit = 1
         lits = []
         out, out10 = {}, {}
@@ -79,7 +92,7 @@ class TestProgram(TestCase):
         return out, out10
 
     def _check(self, prg, prg10, prg_str):
-        '''
+        """
         Check various ways to remap a program.
 
         1. No remapping.
@@ -87,7 +100,7 @@ class TestProgram(TestCase):
         3. Remapping via Backend and Control.
         4. Remapping via remap function without Backend and Control.
         5. Remap a program using the Remapping class.
-        '''
+        """
         self.assertEqual(self.prg, prg)
         self.assertEqual(str(self.prg), prg_str)
 
@@ -108,246 +121,275 @@ class TestProgram(TestCase):
         with ctl.backend() as b:
             for _ in range(10):
                 b.add_atom()
-            rm_prg = prg.copy().remap(Remapping(b, self.prg.output_atoms, self.prg.facts))
+            rm_prg = prg.copy().remap(
+                Remapping(b, self.prg.output_atoms, self.prg.facts)
+            )
         self.assertEqual(str(rm_prg), prg_str)
 
     def test_normal_rule(self):
-        '''
+        """
         Test simple rules.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.rule(False, [1], [2, -3])
         self._check(
             Program(
-                output_atoms=out,
-                rules=[Rule(choice=False, head=[1], body=[2, -3])]),
+                output_atoms=out, rules=[Rule(choice=False, head=[1], body=[2, -3])]
+            ),
             Program(
                 output_atoms=out10,
-                rules=[Rule(choice=False, head=[11], body=[12, -13])]),
-            'a :- b, not c.')
+                rules=[Rule(choice=False, head=[11], body=[12, -13])],
+            ),
+            "a :- b, not c.",
+        )
 
     def test_aux_lit(self):
-        '''
+        """
         Test printing of auxiliary literals.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.rule(False, [4], [1])
-        self.assertEqual(self.prg, Program(
-            output_atoms=out,
-            rules=[Rule(choice=False, head=[4], body=[1])]))
-        self.assertEqual(str(self.prg), '__x4 :- a.')
+        self.assertEqual(
+            self.prg,
+            Program(output_atoms=out, rules=[Rule(choice=False, head=[4], body=[1])]),
+        )
+        self.assertEqual(str(self.prg), "__x4 :- a.")
 
         prg10 = _remap(self.prg, _plus10)
-        self.assertEqual(prg10, Program(
-            output_atoms=out10,
-            rules=[Rule(choice=False, head=[14], body=[11])]))
-        self.assertEqual(str(prg10), '__x14 :- a.')
+        self.assertEqual(
+            prg10,
+            Program(
+                output_atoms=out10, rules=[Rule(choice=False, head=[14], body=[11])]
+            ),
+        )
+        self.assertEqual(str(prg10), "__x14 :- a.")
 
         ctl = Control()
         with ctl.backend() as b:
             b.add_atom()
-            rm_prg = self.prg.copy().remap(Remapping(b, self.prg.output_atoms, self.prg.facts))
-        self.assertEqual(str(rm_prg), '__x5 :- a.')
+            rm_prg = self.prg.copy().remap(
+                Remapping(b, self.prg.output_atoms, self.prg.facts)
+            )
+        self.assertEqual(str(rm_prg), "__x5 :- a.")
 
     def test_facts(self):
-        '''
+        """
         Test simple rules.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
-        self.obs.output_atom(Function('d'), 0)
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
+        self.obs.output_atom(Function("d"), 0)
         self._check(
-            Program(
-                output_atoms=out,
-                facts=[Fact(Function('d'))]),
-            Program(
-                output_atoms=out10,
-                facts=[Fact(Function('d'))]),
-            'd.')
+            Program(output_atoms=out, facts=[Fact(Function("d"))]),
+            Program(output_atoms=out10, facts=[Fact(Function("d"))]),
+            "d.",
+        )
 
     def test_add_choice_rule(self):
-        '''
+        """
         Test choice rules.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.rule(True, [1], [2, -3])
         self._check(
             Program(
-                output_atoms=out,
-                rules=[Rule(choice=True, head=[1], body=[2, -3])]),
+                output_atoms=out, rules=[Rule(choice=True, head=[1], body=[2, -3])]
+            ),
             Program(
-                output_atoms=out10,
-                rules=[Rule(choice=True, head=[11], body=[12, -13])]),
-            '{a} :- b, not c.')
+                output_atoms=out10, rules=[Rule(choice=True, head=[11], body=[12, -13])]
+            ),
+            "{a} :- b, not c.",
+        )
 
     def test_add_weight_rule(self):
-        '''
+        """
         Test weight rules.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.weight_rule(True, [1], 10, [(2, 7), (-3, 5)])
         self._check(
             Program(
                 output_atoms=out,
-                weight_rules=[WeightRule(choice=True, head=[1], lower_bound=10, body=[(2, 7), (-3, 5)])]),
+                weight_rules=[
+                    WeightRule(
+                        choice=True, head=[1], lower_bound=10, body=[(2, 7), (-3, 5)]
+                    )
+                ],
+            ),
             Program(
                 output_atoms=out10,
-                weight_rules=[WeightRule(choice=True, head=[11], lower_bound=10, body=[(12, 7), (-13, 5)])]),
-            '{a} :- 10{7,0: b, 5,1: not c}.')
+                weight_rules=[
+                    WeightRule(
+                        choice=True, head=[11], lower_bound=10, body=[(12, 7), (-13, 5)]
+                    )
+                ],
+            ),
+            "{a} :- 10{7,0: b, 5,1: not c}.",
+        )
 
     def test_add_weight_choice_rule(self):
-        '''
+        """
         Test weight rules that are also choice rules.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.weight_rule(True, [1], 10, [(2, 7), (-3, 5)])
         self._check(
             Program(
                 output_atoms=out,
-                weight_rules=[WeightRule(choice=True, head=[1], lower_bound=10, body=[(2, 7), (-3, 5)])]),
+                weight_rules=[
+                    WeightRule(
+                        choice=True, head=[1], lower_bound=10, body=[(2, 7), (-3, 5)]
+                    )
+                ],
+            ),
             Program(
                 output_atoms=out10,
-                weight_rules=[WeightRule(choice=True, head=[11], lower_bound=10, body=[(12, 7), (-13, 5)])]),
-            '{a} :- 10{7,0: b, 5,1: not c}.')
+                weight_rules=[
+                    WeightRule(
+                        choice=True, head=[11], lower_bound=10, body=[(12, 7), (-13, 5)]
+                    )
+                ],
+            ),
+            "{a} :- 10{7,0: b, 5,1: not c}.",
+        )
 
     def test_add_project(self):
-        '''
+        """
         Test project statements.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.project([1, 2])
         self._check(
-            Program(
-                output_atoms=out,
-                projects=[Project(atom=1), Project(atom=2)]),
-            Program(
-                output_atoms=out10,
-                projects=[Project(atom=11), Project(atom=12)]),
-            '#project a.\n#project b.')
+            Program(output_atoms=out, projects=[Project(atom=1), Project(atom=2)]),
+            Program(output_atoms=out10, projects=[Project(atom=11), Project(atom=12)]),
+            "#project a.\n#project b.",
+        )
 
     def test_add_empty_project(self):
-        '''
+        """
         Test empty projection statement.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.project([])
         self._check(
-            Program(
-                output_atoms=out,
-                projects=[]),
-            Program(
-                output_atoms=out10,
-                projects=[]),
-            '#project x: #false.')
+            Program(output_atoms=out, projects=[]),
+            Program(output_atoms=out10, projects=[]),
+            "#project x: #false.",
+        )
 
     def test_add_external(self):
-        '''
+        """
         Test external statement.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.external(1, TruthValue.True_)
         self.obs.external(2, TruthValue.Free)
         self.obs.external(3, TruthValue.False_)
         self._check(
             Program(
                 output_atoms=out,
-                externals=[External(atom=1, value=TruthValue.True_),
-                           External(atom=2, value=TruthValue.Free),
-                           External(atom=3, value=TruthValue.False_)]),
+                externals=[
+                    External(atom=1, value=TruthValue.True_),
+                    External(atom=2, value=TruthValue.Free),
+                    External(atom=3, value=TruthValue.False_),
+                ],
+            ),
             Program(
                 output_atoms=out10,
-                externals=[External(atom=11, value=TruthValue.True_),
-                           External(atom=12, value=TruthValue.Free),
-                           External(atom=13, value=TruthValue.False_)]),
-            '#external a. [True]\n'
-            '#external b. [Free]\n'
-            '#external c. [False]')
+                externals=[
+                    External(atom=11, value=TruthValue.True_),
+                    External(atom=12, value=TruthValue.Free),
+                    External(atom=13, value=TruthValue.False_),
+                ],
+            ),
+            "#external a. [True]\n" "#external b. [Free]\n" "#external c. [False]",
+        )
 
     def test_add_minimize(self):
-        '''
+        """
         Test minimize statement.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.minimize(10, [(1, 7), (3, 5)])
         self._check(
             Program(
                 output_atoms=out,
-                minimizes=[Minimize(priority=10, literals=[(1, 7), (3, 5)])]),
+                minimizes=[Minimize(priority=10, literals=[(1, 7), (3, 5)])],
+            ),
             Program(
                 output_atoms=out10,
-                minimizes=[Minimize(priority=10, literals=[(11, 7), (13, 5)])]),
-            '#minimize{7@10,0: a; 5@10,1: c}.')
+                minimizes=[Minimize(priority=10, literals=[(11, 7), (13, 5)])],
+            ),
+            "#minimize{7@10,0: a; 5@10,1: c}.",
+        )
 
     def test_add_edge(self):
-        '''
+        """
         Test edge statement.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.acyc_edge(1, 2, [1])
         self._check(
-            Program(
-                output_atoms=out,
-                edges=[Edge(1, 2, [1])]),
-            Program(
-                output_atoms=out10,
-                edges=[Edge(1, 2, [11])]),
-            '#edge (1,2): a.')
+            Program(output_atoms=out, edges=[Edge(1, 2, [1])]),
+            Program(output_atoms=out10, edges=[Edge(1, 2, [11])]),
+            "#edge (1,2): a.",
+        )
 
     def test_add_heuristic(self):
-        '''
+        """
         Test heuristic statement.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.heuristic(1, HeuristicType.Level, 2, 3, [2])
         self._check(
             Program(
                 output_atoms=out,
-                heuristics=[Heuristic(1, HeuristicType.Level, 2, 3, [2])]),
+                heuristics=[Heuristic(1, HeuristicType.Level, 2, 3, [2])],
+            ),
             Program(
                 output_atoms=out10,
-                heuristics=[Heuristic(11, HeuristicType.Level, 2, 3, [12])]),
-            '#heuristic a: b. [2@3, Level]')
+                heuristics=[Heuristic(11, HeuristicType.Level, 2, 3, [12])],
+            ),
+            "#heuristic a: b. [2@3, Level]",
+        )
 
     def test_add_assume(self):
-        '''
+        """
         Test assumptions.
 
         TODO: this test currently fails but probably has to be fixed in clingo
         because assumptions are not observed properly.
-        '''
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.assume([1, 3])
         self._check(
-            Program(
-                output_atoms=out,
-                assumptions=[1, 3]),
-            Program(
-                output_atoms=out10,
-                assumptions=[11, 13]),
-            '% assumptions: a, c')
+            Program(output_atoms=out, assumptions=[1, 3]),
+            Program(output_atoms=out10, assumptions=[11, 13]),
+            "% assumptions: a, c",
+        )
 
     def test_add_show(self):
-        '''
+        """
         Test show statement.
-        '''
-        t = Function('t')
-        out, out10 = self._add_atoms('a', 'b', 'c')
+        """
+        t = Function("t")
+        out, out10 = self._add_atoms("a", "b", "c")
         self.obs.output_term(t, [1])
         self._check(
-            Program(
-                output_atoms=out,
-                shows=[Show(t, [1])]),
-            Program(
-                output_atoms=out10,
-                shows=[Show(t, [11])]),
-            '#show t: a.')
+            Program(output_atoms=out, shows=[Show(t, [1])]),
+            Program(output_atoms=out10, shows=[Show(t, [11])]),
+            "#show t: a.",
+        )
 
     def test_control(self):
-        '''
+        """
         Test observer together with a control object.
-        '''
+        """
         ctl = Control()
         ctl.register_observer(self.obs)
-        ctl.add('base', [], '''\
+        ctl.add(
+            "base",
+            [],
+            """\
             b.
             {c}.
             a :- b, not c.
@@ -355,21 +397,28 @@ class TestProgram(TestCase):
             #project a.
             #project b.
             #external a.
-            ''')
-        ctl.ground([('base', [])])
+            """,
+        )
+        ctl.ground([("base", [])])
 
-        a, b, c = (Function(s) for s in ('a', 'b', 'c'))
+        a, b, c = (Function(s) for s in ("a", "b", "c"))
         la, lb, lc = (ctl.symbolic_atoms[sym].literal for sym in (a, b, c))
 
         self.prg.sort()
 
-        self.assertEqual(self.prg, Program(
-            output_atoms={la: a, lc: c},
-            shows=[],
-            facts=[Fact(symbol=b)],
-            rules=[Rule(choice=False, head=[lb], body=[]),
-                   Rule(choice=False, head=[la], body=[-lc]),
-                   Rule(choice=True, head=[lc], body=[])],
-            minimizes=[Minimize(priority=10, literals=[(lc, 5), (la, 7)])],
-            externals=[External(atom=la, value=TruthValue.False_)],
-            projects=[Project(atom=lb), Project(atom=la)]).sort())
+        self.assertEqual(
+            self.prg,
+            Program(
+                output_atoms={la: a, lc: c},
+                shows=[],
+                facts=[Fact(symbol=b)],
+                rules=[
+                    Rule(choice=False, head=[lb], body=[]),
+                    Rule(choice=False, head=[la], body=[-lc]),
+                    Rule(choice=True, head=[lc], body=[]),
+                ],
+                minimizes=[Minimize(priority=10, literals=[(lc, 5), (la, 7)])],
+                externals=[External(atom=la, value=TruthValue.False_)],
+                projects=[Project(atom=lb), Project(atom=la)],
+            ).sort(),
+        )

--- a/clingox/tests/test_solving.py
+++ b/clingox/tests/test_solving.py
@@ -10,47 +10,37 @@ from ..solving import approximate
 
 
 class TestSolving(TestCase):
-    '''
+    """
     Tests for solving module.
-    '''
+    """
 
     def approximate(self, prg: str, expected_res):
-        '''
+        """
         Auxiliary function to test approximate.
-        '''
+        """
         ctl = Control()
         ctl.add("base", [], prg)
         ctl.ground([("base", [])])
         res = approximate(ctl)
         if res:
-            sorted_res = (sorted([str(s) for s in res[0]]),
-                          sorted([str(s) for s in res[1]]))
+            sorted_res = (
+                sorted([str(s) for s in res[0]]),
+                sorted([str(s) for s in res[1]]),
+            )
         else:
             sorted_res = None
 
         self.assertEqual(sorted_res, expected_res)
 
     def test_approximate(self):
-        '''
+        """
         Tests for approximate.
-        '''
+        """
+        self.approximate("a. {b}. c :- not d." "d :- not c. e :- not e.", None)
         self.approximate(
-            'a. {b}. c :- not d.'
-            'd :- not c. e :- not e.',
-            None)
-        self.approximate(
-            'a. {b}. c :- not d.'
-            'd :- not c.',
-            (['a'], ['a', 'b', 'c', 'd']))
-        self.approximate(
-            '{a}. :- not a.',
-            (['a'], ['a']))
-        self.approximate(
-            '{a}. :- a.',
-            ([], []))
-        self.approximate(
-            'a, b.',
-            ([], ['a', 'b']))
-        self.approximate(
-            'a, b. :- not a.',
-            (['a'], ['a']))
+            "a. {b}. c :- not d." "d :- not c.", (["a"], ["a", "b", "c", "d"])
+        )
+        self.approximate("{a}. :- not a.", (["a"], ["a"]))
+        self.approximate("{a}. :- a.", ([], []))
+        self.approximate("a, b.", ([], ["a", "b"]))
+        self.approximate("a, b. :- not a.", (["a"], ["a"]))

--- a/clingox/tests/test_theory.py
+++ b/clingox/tests/test_theory.py
@@ -14,7 +14,10 @@ def eval_term_sym(s: str) -> Symbol:
     Evaluate the given theory term and return its string representation.
     """
     ctl = Control()
-    ctl.add("base", [], f"""
+    ctl.add(
+        "base",
+        [],
+        f"""
 #theory test {{
     t {{
     +  : 3, unary;
@@ -31,7 +34,8 @@ def eval_term_sym(s: str) -> Symbol:
     &a/0 : t, head
 }}.
 &a {{{s}}}.
-""")
+""",
+    )
     ctl.ground([("base", [])])
     for x in ctl.theory_atoms:
         return evaluate(x.elements[0].terms[0])
@@ -46,14 +50,14 @@ def eval_term(s: str) -> str:
 
 
 class TestTheory(TestCase):
-    '''
+    """
     Tests for theory term evaluation.
-    '''
+    """
 
     def test_binary(self):
-        '''
+        """
         Test evaluation of binary terms.
-        '''
+        """
         self.assertEqual(eval_term("2+3"), "5")
         self.assertEqual(eval_term("2-3"), "-1")
         self.assertEqual(eval_term("2*3"), "6")
@@ -62,9 +66,9 @@ class TestTheory(TestCase):
         self.assertEqual(eval_term("2**3"), "8")
 
     def test_unary(self):
-        '''
+        """
         Test evaluation of unary terms.
-        '''
+        """
         self.assertEqual(eval_term("-1"), "-1")
         self.assertEqual(eval_term("+1"), "1")
         self.assertEqual(eval_term("-f"), "-f")
@@ -72,22 +76,22 @@ class TestTheory(TestCase):
         self.assertEqual(eval_term("-(-f(x))"), "f(x)")
 
     def test_nesting(self):
-        '''
+        """
         Test evaluation of nested terms
-        '''
+        """
         self.assertEqual(eval_term("f(2+3*4,-g(-1))"), "f(14,-g(-1))")
         self.assertEqual(eval_term("f(2+3*4,-g(-1),0)"), "f(14,-g(-1),0)")
 
     def test_string(self):
-        '''
+        """
         Test evaluation of strings.
-        '''
+        """
         self.assertEqual(eval_term_sym('"a\\\\b\\nc\\"d"'), String('a\\b\nc"d'))
 
     def test_error(self):
-        '''
+        """
         Test failed term evaluation.
-        '''
+        """
         self.assertRaises(TypeError, eval_term, "-(1,2)")
         self.assertRaises(TypeError, eval_term, "+a")
         self.assertRaises(RuntimeError, eval_term, "{1}")

--- a/clingox/theory.py
+++ b/clingox/theory.py
@@ -37,23 +37,30 @@ from typing import Any
 
 from clingo import Symbol, Function, String, Tuple_, Number, SymbolType, TheoryTermType
 
-__all__ = ['evaluate', 'invert_symbol', 'is_clingo_operator', 'is_operator', 'require_number', 'TermEvaluator']
+__all__ = [
+    "evaluate",
+    "invert_symbol",
+    "is_clingo_operator",
+    "is_operator",
+    "require_number",
+    "TermEvaluator",
+]
 __pdoc__ = {}
 
 
 def require_number(x: Symbol) -> int:
-    '''
+    """
     Requires the argument to be a number returning the given number or throwing
     a type error.
-    '''
+    """
     if x.type == SymbolType.Number:
         return x.number
 
-    raise TypeError('number exepected')
+    raise TypeError("number exepected")
 
 
 def invert_symbol(sym: Symbol) -> Symbol:
-    '''
+    """
     Inverts the given symbol.
 
     Parameters
@@ -64,26 +71,26 @@ def invert_symbol(sym: Symbol) -> Symbol:
     Returns
     -------
     The inverted symbol.
-    '''
+    """
     if sym.type == SymbolType.Number:
         return Number(-sym.number)
 
     if sym.type == SymbolType.Function and sym.name:
         return Function(sym.name, sym.arguments, not sym.positive)
 
-    raise TypeError('cannot invert symbol')
+    raise TypeError("cannot invert symbol")
 
 
 def is_clingo_operator(op: str):
-    '''
+    """
     Return true if the given string is a operator as supported by the
     Evaluator.
-    '''
-    return op in ('+', '-', '*', '\\', '/')
+    """
+    return op in ("+", "-", "*", "\\", "/")
 
 
 def is_operator(op: str):
-    '''
+    """
     Return true if the given string is an operator.
 
     Parameters
@@ -94,43 +101,43 @@ def is_operator(op: str):
     Returns
     -------
     Whether the string is an operator name.
-    '''
+    """
     return op and op[0] in "/!<=>+-*\\?&@|:;~^."
 
 
 def _unquote(s: str) -> str:
-    '''
+    """
     Remove quotes in the same fashion as clingo.
-    '''
+    """
     ret = []
     slash = False
     for c in s:
         if slash:
-            if c == 'n':
-                ret.append('\n')
+            if c == "n":
+                ret.append("\n")
             else:
                 assert c in '\\"'
                 ret.append(c)
             slash = False
-        elif c == '\\':
+        elif c == "\\":
             slash = True
         else:
             ret.append(c)
 
-    return ''.join(ret)
+    return "".join(ret)
 
 
 class TermEvaluator:
-    '''
+    """
     This class provides a call operator to evaluate the operators in a theory
     term in the same fashion as clingo evaluates its arithmetic functions.
 
     This class can easily be extended for additional binary and unary
     operators.
-    '''
+    """
 
     def evaluate_binary(self, op: str, lhs: Symbol, rhs: Symbol) -> Symbol:
-        '''
+        """
         Evaluate binary terms as clingo would.
 
         Parameters
@@ -145,7 +152,7 @@ class TermEvaluator:
         Returns
         -------
         The evaluated operator in form of a symbol.
-        '''
+        """
         if op == "+":
             return Number(require_number(lhs) + require_number(rhs))
         if op == "-":
@@ -164,12 +171,12 @@ class TermEvaluator:
             return Number(require_number(lhs) // require_number(rhs))
 
         if is_operator(op):
-            raise AttributeError('unexpected operator')
+            raise AttributeError("unexpected operator")
 
         return Function(op, [lhs, rhs])
 
     def evaluate_unary(self, op: str, arg: Symbol):
-        '''
+        """
         Evaluate unary terms as clingo would.
 
         Parameters
@@ -182,18 +189,18 @@ class TermEvaluator:
         Returns
         -------
         The evaluated operator in form of a symbol.
-        '''
+        """
         if op == "+":
             return Number(require_number(arg))
         if op == "-":
             return invert_symbol(arg)
         if is_operator(op):
-            raise AttributeError('unexpected operator')
+            raise AttributeError("unexpected operator")
 
         return Function(op, [arg])
 
     def __call__(self, term: Any):
-        '''
+        """
         Evaluate the given term.
 
         Parameters
@@ -204,7 +211,7 @@ class TermEvaluator:
         Returns
         -------
         The evaluated term in form of a symbol.
-        '''
+        """
         # tuples
         if term.type == TheoryTermType.Tuple:
             return Tuple_([self(x) for x in term.arguments])
@@ -237,11 +244,11 @@ class TermEvaluator:
         raise RuntimeError("cannot evaluate term")
 
 
-__pdoc__['TermEvaluator.__call__'] = True
+__pdoc__["TermEvaluator.__call__"] = True
 
 
 def evaluate(term: Any) -> Symbol:
-    '''
+    """
     Evaluates the operators in a theory term in the same fashion as clingo
     evaluates its arithmetic functions.
 
@@ -256,5 +263,5 @@ def evaluate(term: Any) -> Symbol:
     Returns
     -------
     The evaluated term in form of a symbol.
-    '''
+    """
     return TermEvaluator()(term)


### PR DESCRIPTION
Issue #25

This patch automatically formats the code with [black](https://pypi.org/project/black/).
It works combining a github action and a post-commit hook.

The post-commit hook auto-formats the code after each commit.
Files appear as modified and, ```git commit -am"black"``` can be executed to push the formatting changes.
The github action does not modify the files. It only checks that the format is correct.

Black makes some decisions incompatible with pylint so I added ```disable implicit-str-concat``` in pylintrc.

The documented case is using a pre-commit hook instead of a post-commit one. With a pre-commit, the commit is aborted, the autoformat happens and you need to make the commit again. This is great from a history point of view, because no commit with bad format goes into history, but it seems quite dangerous if something goes wrong. Your code is changed in place before committed, so it never goes into git. It may even be lost forever, I don't know if there is a way to recover it.
- If the the need for an extra manual commit with a post-commit is found cumbersome, it may be possible to make this  commit automatically
- The extra commit can be latter removed from history if need by iterative rebase and squash.
Doing this manually seems safe. If one really trust the tool, the pre-commit is simpler.

Both pre-commit and post-commit hooks mess with iterative rebase and squash. Technically, this creates new commits, so the hooks are executed. Luckily there is a way to disable the hooks for some command:
```
SKIP=black git rebase -i <ref>
```
Probably, one can add something to make this automatic.

It may be possible to do all in a github action, but this does not seem to be supported by the official action. There may be third party actions of we can write our own.