### PR TITLE
Jorge/get body callback

### DIFF
--- a/clingox/ast.py
+++ b/clingox/ast.py
@@ -1147,10 +1147,8 @@ def get_body(
             # if lit.literal.sign not in signs:
             #     continue
             include_lit = _eval_predicate(conditional_literals_predicate, lit)
-        if not include_lit:
-            continue
-
-        body.append(lit)
+        if include_lit:
+            body.append(lit)
 
     return body
 

--- a/clingox/ast.py
+++ b/clingox/ast.py
@@ -149,6 +149,7 @@ from .theory import is_operator
 __all__ = [
     "Arity",
     "Associativity",
+    "ASTPredicate",
     "AtomTable",
     "OperatorTable",
     "TheoryParser",
@@ -167,8 +168,8 @@ __all__ = [
     "rename_symbolic_atoms",
     "str_to_location",
     "theory_parser_from_definition",
-    "theory_term_to_term",
     "theory_term_to_literal",
+    "theory_term_to_term",
 ]
 
 
@@ -1106,7 +1107,7 @@ def _eval_predicate(predicate: ASTPredicate, arg: AST) -> bool:
 def get_body(
     stm: AST,
     symbolic_atom_predicate: ASTPredicate = True,
-    theory_atoms_predicate: ASTPredicate = True,
+    theory_atom_predicate: ASTPredicate = True,
     aggregate_predicate: ASTPredicate = True,
     conditional_literal_predicate: ASTPredicate = True,
     signs: Container[Sign] = (Sign.NoSign, Sign.Negation, Sign.DoubleNegation),
@@ -1119,15 +1120,15 @@ def get_body(
     stm
         An `AST` for a statement with a body.
     symbolic_atom_predicate
-        Whether a symbolic atoms should be include or excluded.
-    theory_atoms_predicate
-        Whether theory atoms should be include or excluded.
+        Predicate to filter symbolic atoms.
+    theory_atom_predicate
+        Predicate to filter theory atoms.
     aggregate_predicate
-        Whether aggregates should be include or excluded.
+        Predicate to filter aggregates.
     conditional_literal_predicate
-        Whether conditional literals should be include or excluded.
+        Predicate to filter conditional literals.
     signs
-        Literals having any of the given signs are excluded.
+        Only include literals with the given signs.
 
     Returns
     -------
@@ -1135,7 +1136,7 @@ def get_body(
 
     Notes
     -----
-    An ASTPredicate is a callable that takes an `AST` and returns a boolean.
+    An `ASTPredicate` is a callable that takes an `AST` and returns a Boolean.
     Booleans `True` and `False` are also accepted, meaning that the predicate
     is always `True` or `False`, respectively.
     """
@@ -1156,7 +1157,7 @@ def get_body(
             ) and not _eval_predicate(aggregate_predicate, atom):
                 continue
             if atom.ast_type == ASTType.TheoryAtom and not _eval_predicate(
-                theory_atoms_predicate, atom
+                theory_atom_predicate, atom
             ):
                 continue
         elif lit.ast_type == ASTType.ConditionalLiteral:

--- a/clingox/ast.py
+++ b/clingox/ast.py
@@ -1132,23 +1132,30 @@ def get_body(
     body: List[AST] = []
 
     for lit in stm.body:
-        include_lit = True
         if lit.ast_type == ASTType.Literal:
             atom = lit.atom
             if lit.sign not in signs:
                 continue
-            if atom.ast_type == ASTType.SymbolicAtom:
-                include_lit = _eval_predicate(symbolic_atom_predicate, atom.symbol)
-            elif atom.ast_type in (ASTType.Aggregate, ASTType.BodyAggregate):
-                include_lit = _eval_predicate(aggregate_predicate, atom)
-            elif atom.ast_type == ASTType.TheoryAtom:
-                include_lit = _eval_predicate(theory_atoms_predicate, atom)
+            if atom.ast_type == ASTType.SymbolicAtom and not _eval_predicate(
+                symbolic_atom_predicate, atom.symbol
+            ):
+                continue
+            if atom.ast_type in (
+                ASTType.Aggregate,
+                ASTType.BodyAggregate,
+            ) and not _eval_predicate(aggregate_predicate, atom):
+                continue
+            if atom.ast_type == ASTType.TheoryAtom and not _eval_predicate(
+                theory_atoms_predicate, atom
+            ):
+                continue
         elif lit.ast_type == ASTType.ConditionalLiteral:
             # if lit.literal.sign not in signs:
             #     continue
-            include_lit = _eval_predicate(conditional_literals_predicate, lit)
-        if include_lit:
-            body.append(lit)
+            if not _eval_predicate(conditional_literals_predicate, lit):
+                continue
+
+        body.append(lit)
 
     return body
 

--- a/clingox/ast.py
+++ b/clingox/ast.py
@@ -1096,7 +1096,7 @@ def dict_to_ast(x: dict) -> AST:
 def get_body(
     stm: AST,
     exclude_signs: Container[Sign] = (),
-    exclude_theory_atoms: bool = False,
+    exclude_theory_atoms: Union[bool, Callable[[AST], bool]] = False,
     exclude_aggregates: bool = False,
     exclude_conditional_literals: bool = False,
 ) -> List[AST]:
@@ -1129,12 +1129,17 @@ def get_body(
             atom = lit.atom
             if lit.sign in exclude_signs:
                 continue
-            if exclude_theory_atoms and atom.ast_type == ASTType.TheoryAtom:
-                continue
             if exclude_aggregates and atom.ast_type == ASTType.Aggregate:
                 continue
             if exclude_aggregates and atom.ast_type == ASTType.BodyAggregate:
                 continue
+            if atom.ast_type == ASTType.TheoryAtom:
+                if isinstance(exclude_theory_atoms, bool):
+                    exclude_this_theory_atom = exclude_theory_atoms
+                else:
+                    exclude_this_theory_atom = exclude_theory_atoms(atom)
+                if exclude_this_theory_atom:
+                    continue
 
         if lit.ast_type == ASTType.ConditionalLiteral:
             if exclude_conditional_literals:

--- a/clingox/tests/test_ast.py
+++ b/clingox/tests/test_ast.py
@@ -2359,7 +2359,7 @@ class TestAST(TestCase):
         body: Sequence[str],
         signs: Container[Sign] = (Sign.NoSign,),
         symbolic_atom_predicate: Union[Callable[[AST], bool], bool] = True,
-        theory_atoms_predicate: Union[Callable[[AST], bool], bool] = True,
+        theory_atom_predicate: Union[Callable[[AST], bool], bool] = True,
         aggregate_predicate: Union[Callable[[AST], bool], bool] = True,
         conditional_literal_predicate: Union[Callable[[AST], bool], bool] = True,
     ):
@@ -2369,7 +2369,7 @@ class TestAST(TestCase):
         res = get_body(
             last_stm(stm),
             symbolic_atom_predicate,
-            theory_atoms_predicate,
+            theory_atom_predicate,
             aggregate_predicate,
             conditional_literal_predicate,
             signs,
@@ -2401,27 +2401,27 @@ class TestAST(TestCase):
         self.helper_get_body(
             "a(X) :- b(X), c(Y), not d(X), not not e(X,Y).",
             ["b(X)", "c(Y)"],
-            theory_atoms_predicate=False,
+            theory_atom_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.",
             ["b(X)", "c(Y)", "Z = #sum { X: d(X) }"],
-            theory_atoms_predicate=False,
+            theory_atom_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.",
             ["b(X)", "c(Y)"],
-            theory_atoms_predicate=False,
+            theory_atom_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), Z = { d(X) }.",
             ["b(X)", "c(Y)", "Z = { d(X) }"],
-            theory_atoms_predicate=False,
+            theory_atom_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
             ["b(X)", "c(Y)", "d(Z): e(X,Z)"],
-            theory_atoms_predicate=False,
+            theory_atom_predicate=False,
         )
 
         self.helper_get_body(
@@ -2453,31 +2453,31 @@ class TestAST(TestCase):
         self.helper_get_body(
             "a(X) :- b(X), c(Y), not d(X), not not e(X,Y).",
             ["b(X)", "c(Y)"],
-            theory_atoms_predicate=False,
+            theory_atom_predicate=False,
             aggregate_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.",
             ["b(X)", "c(Y)"],
-            theory_atoms_predicate=False,
+            theory_atom_predicate=False,
             aggregate_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.",
             ["b(X)", "c(Y)"],
-            theory_atoms_predicate=False,
+            theory_atom_predicate=False,
             aggregate_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), Z = { d(X) }.",
             ["b(X)", "c(Y)"],
-            theory_atoms_predicate=False,
+            theory_atom_predicate=False,
             aggregate_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
             ["b(X)", "c(Y)", "d(Z): e(X,Z)"],
-            theory_atoms_predicate=False,
+            theory_atom_predicate=False,
             aggregate_predicate=False,
         )
 
@@ -2623,7 +2623,7 @@ class TestAST(TestCase):
         self.helper_get_body(
             "a(X) :- &k{ b(X) }, &k{ not c(X)}.",
             ["&k { b(X) }"],
-            theory_atoms_predicate=lambda x: not (
+            theory_atom_predicate=lambda x: not (
                 x.elements
                 and x.elements[0].terms
                 and x.elements[0].terms[0].ast_type == ASTType.TheoryUnparsedTerm

--- a/clingox/tests/test_ast.py
+++ b/clingox/tests/test_ast.py
@@ -2634,10 +2634,15 @@ class TestAST(TestCase):
                 and x.elements[0].terms[0].elements[0].operators[0] == "not"
             ),
         )
-
         self.helper_get_body(
-            "a(X) :- b(X), c(Y), d(Z): e(X,Z); not d(Z): e(X,Z).",
-            ["b(X)", "c(Y)", "d(Z): e(X,Z)"],
+            "a(X) :- b(X), not c(Y), d(Z): e(X,Z); not d(Z): e(X,Z).",
+            ["b(X)", "d(Z): e(X,Z)", "not d(Z): e(X,Z)"],
+            signs=(Sign.NoSign,),
+        )
+        self.helper_get_body(
+            "a(X) :- b(X), not c(Y), d(Z): e(X,Z); not d(Z): e(X,Z).",
+            ["b(X)", "d(Z): e(X,Z)"],
+            signs=(Sign.NoSign,),
             conditional_literals_predicate=lambda x: x.literal.sign != Sign.Negation,
         )
 

--- a/clingox/tests/test_ast.py
+++ b/clingox/tests/test_ast.py
@@ -2361,7 +2361,7 @@ class TestAST(TestCase):
         symbolic_atom_predicate: Union[Callable[[AST], bool], bool] = True,
         theory_atoms_predicate: Union[Callable[[AST], bool], bool] = True,
         aggregate_predicate: Union[Callable[[AST], bool], bool] = True,
-        conditional_literals_predicate: Union[Callable[[AST], bool], bool] = True,
+        conditional_literal_predicate: Union[Callable[[AST], bool], bool] = True,
     ):
         """
         Helper for testing get_body.
@@ -2371,7 +2371,7 @@ class TestAST(TestCase):
             symbolic_atom_predicate,
             theory_atoms_predicate,
             aggregate_predicate,
-            conditional_literals_predicate,
+            conditional_literal_predicate,
             signs,
         )
         self.assertListEqual(sorted(body), sorted(str(s) for s in res))
@@ -2567,7 +2567,7 @@ class TestAST(TestCase):
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
-            ["d(Z): e(X,Z)"],
+            [],
             signs=(
                 Sign.Negation,
                 Sign.DoubleNegation,
@@ -2577,27 +2577,27 @@ class TestAST(TestCase):
         self.helper_get_body(
             "a(X) :- b(X), c(Y), not d(X), not not e(X,Y).",
             ["b(X)", "c(Y)"],
-            conditional_literals_predicate=False,
+            conditional_literal_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), Z = #sum { X: d(X) }.",
             ["b(X)", "c(Y)", "Z = #sum { X: d(X) }"],
-            conditional_literals_predicate=False,
+            conditional_literal_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), &sum { X: d(X) } = Z.",
             ["b(X)", "c(Y)", "&sum { X: d(X) } = Z"],
-            conditional_literals_predicate=False,
+            conditional_literal_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), Z = { d(X) }.",
             ["b(X)", "c(Y)", "Z = { d(X) }"],
-            conditional_literals_predicate=False,
+            conditional_literal_predicate=False,
         )
         self.helper_get_body(
             "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
             ["b(X)", "c(Y)"],
-            conditional_literals_predicate=False,
+            conditional_literal_predicate=False,
         )
 
         self.helper_get_body(
@@ -2636,14 +2636,14 @@ class TestAST(TestCase):
         )
         self.helper_get_body(
             "a(X) :- b(X), not c(Y), d(Z): e(X,Z); not d(Z): e(X,Z).",
-            ["b(X)", "d(Z): e(X,Z)", "not d(Z): e(X,Z)"],
+            ["b(X)", "d(Z): e(X,Z)"],
             signs=(Sign.NoSign,),
         )
         self.helper_get_body(
             "a(X) :- b(X), not c(Y), d(Z): e(X,Z); not d(Z): e(X,Z).",
             ["b(X)", "d(Z): e(X,Z)"],
             signs=(Sign.NoSign,),
-            conditional_literals_predicate=lambda x: x.literal.sign != Sign.Negation,
+            conditional_literal_predicate=lambda x: x.literal.sign != Sign.Negation,
         )
 
     def _aux_theory_term_to_term(self, s: str) -> None:

--- a/clingox/tests/test_ast.py
+++ b/clingox/tests/test_ast.py
@@ -17,6 +17,7 @@ from clingo.ast import (
     Transformer,
     Variable,
     parse_string,
+    ASTType,
 )
 from .. import ast
 from ..ast import (
@@ -2577,6 +2578,21 @@ class TestAST(TestCase):
             "a(X) :- b(X), c(Y), d(Z): e(X,Z).",
             ["b(X)", "c(Y)"],
             exclude_conditional_literals=True,
+        )
+
+        self.helper_get_body(
+            "a(X) :- &k{ b(X) }, &k{ not c(X)}.",
+            ["&k { b(X) }"],
+            exclude_theory_atoms=lambda x: (
+                len(x.elements) > 0
+                and len(x.elements[0].terms) > 0
+                and x.elements[0].terms[0].ast_type == ASTType.TheoryUnparsedTerm
+                and len(x.elements[0].terms[0].elements) > 0
+                and x.elements[0].terms[0].elements[0].ast_type
+                == ASTType.TheoryUnparsedTermElement
+                and len(x.elements[0].terms[0].elements[0].operators) > 0
+                and x.elements[0].terms[0].elements[0].operators[0] == "not"
+            ),
         )
 
     def _aux_theory_term_to_term(self, s: str) -> None:


### PR DESCRIPTION
I realized that ```get_body()``` is not general enough for ```eclingo```.  For instance, with rule
```
a(X) :- &k{ b(X) }, &k{ not c(X)}.
```
we want to obtain the positive body
```
["&k { b(X) }"]
```
See test https://github.com/jorgefandinno/python-clingox/blob/1ca03c8e071192f3bf78995e70490afe8aa5e9b5/clingox/tests/test_ast.py#L2584

Obviously , this is ```eclingo``` specific. In general, the user of the library should be able to inspect the theory atom to decide if it should be excluded or not.

This pull request achieves that by allowing to pass a callback as ```exclude_theory_atoms```

